### PR TITLE
`:first-of-type` & list rendering fixes

### DIFF
--- a/packages/react-components/src/components/typography/Prose.js
+++ b/packages/react-components/src/components/typography/Prose.js
@@ -20,7 +20,7 @@ function getTag(tagName, styleFn) {
 }
 
 export const ol = (theme) => css`
-  div>p:first-child {
+  div>p:first-of-type {
     margin-top: 0;
   }
   ol {

--- a/packages/react-components/src/entities/EventSidebar/details/Groups.js
+++ b/packages/react-components/src/entities/EventSidebar/details/Groups.js
@@ -48,15 +48,16 @@ export function Structure({ event, setActiveEvent }) {
   }
   return <>
     <span>
-      { combinedHierarchy.map((node, idx) =>
-          <StructureNode
-              eventType={node.name}
-              eventID={node.key}
-              datasetKey={event.datasetKey}
-              idx={idx}
-              isLast={(combinedHierarchy.length -1) == idx}
-              setActiveEvent={setActiveEvent}
-          />)
+      {combinedHierarchy.map((node, idx) =>
+        <StructureNode
+            key={node.key}
+            eventType={node.name}
+            eventID={node.key}
+            datasetKey={event.datasetKey}
+            idx={idx}
+            isLast={(combinedHierarchy.length -1) == idx}
+            setActiveEvent={setActiveEvent}
+        />)
       }
     </span>
   </>;

--- a/packages/react-components/src/entities/EventSidebar/details/Tree/SingleTree.js
+++ b/packages/react-components/src/entities/EventSidebar/details/Tree/SingleTree.js
@@ -42,7 +42,14 @@ export function SingleTreeN({ node, setViewEvent, setSearch }) {
       </span>
     {hasChildren &&
       <ul>
-        {node.children.map(child => <SingleTreeN node={ child } setViewEvent={setViewEvent} setSearch={setSearch} />)}
+        {node.children.map((child) => (
+          <SingleTreeN
+            key={child.key}
+            node={child}
+            setViewEvent={setViewEvent}
+            setSearch={setSearch}
+          />
+        ))}
       </ul>}
     </li>;
 }

--- a/packages/react-components/src/entities/EventSidebar/details/Tree/Tree.js
+++ b/packages/react-components/src/entities/EventSidebar/details/Tree/Tree.js
@@ -20,7 +20,7 @@ export function TreeN({ treeNode }) {
       <span className={ treeNode.isSelected ? 'selected' : ''}>{ treeNode.value }</span>
     { hasChildren &&
         <ul>
-          {treeNode.children.map(childNode => <TreeN treeNode={childNode} />)}
+          {treeNode.children.map(childNode => <TreeN key={childNode.key} treeNode={childNode} />)}
         </ul>
     }
     </li>

--- a/packages/react-components/src/entities/EventSidebar/details/Tree/styles.js
+++ b/packages/react-components/src/entities/EventSidebar/details/Tree/styles.js
@@ -44,7 +44,7 @@ export const tree = ({ theme, ...props }) => css`
       :only-child {
         padding-top: 0;
       }
-      :first-child::before,
+      :first-of-type::before,
       :last-child::after {
         border: 0 none;
       }
@@ -52,7 +52,7 @@ export const tree = ({ theme, ...props }) => css`
         border-right: 1px solid #ccc;
         border-radius: 0 5px 0 0;
       }
-      :first-child::after{
+      :first-of-type::after{
         border-radius: 5px 0 0 0;
       }
   }

--- a/packages/react-components/src/entities/EventSidebar/details/properties.js
+++ b/packages/react-components/src/entities/EventSidebar/details/properties.js
@@ -126,7 +126,12 @@ export function EnumField({ getEnum, ...props }) {
   const { value } = props.term;
   const values = Array.isArray(value) ? value : [value];
   return <Field {...props}>
-    {values.map((enumValue, i) => <>{i > 0 && ' ● '}<FormattedMessage key={i} id={getEnum(enumValue)} defaultMessage={enumValue} /></>)}
+    {values.map((enumValue, i) => (
+      <React.Fragment key={i}>
+        {i > 0 && ' ● '}
+        <FormattedMessage id={getEnum(enumValue)} defaultMessage={enumValue} />
+      </React.Fragment>
+    ))}
   </Field>
 }
 

--- a/packages/react-components/src/entities/OccurrenceSidebar/details/properties.js
+++ b/packages/react-components/src/entities/OccurrenceSidebar/details/properties.js
@@ -38,7 +38,12 @@ export function EnumField({ getEnum, ...props }) {
   const { value } = props.term;
   const values = Array.isArray(value) ? value : [value];
   return <Field {...props}>
-    {values.map((enumValue, i) => <>{i > 0 && ' ● '}<FormattedMessage key={i} id={getEnum(enumValue)} defaultMessage={enumValue} /></>)}
+    {values.map((enumValue, i) => (
+      <React.Fragment key={i}>
+        {i > 0 && ' ● '}
+        <FormattedMessage id={getEnum(enumValue)} defaultMessage={enumValue} />
+      </React.Fragment>
+    ))}
   </Field>
 }
 


### PR DESCRIPTION
This PR fixes several minor issues related to:
- Using the `:first-child` selector (rather than `:first-of-type`)
- Rendering lists / multiple items without using the `key` attribute