### PR TITLE
Fixes 'view related events' and event data structure child querying not working

### DIFF
--- a/packages/react-components/src/search/EventSearch/views/Table/EventsTable.js
+++ b/packages/react-components/src/search/EventSearch/views/Table/EventsTable.js
@@ -58,13 +58,13 @@ export const EventsTable = ({ first, prev, next, size, from, results, total, loa
   }
 
   function addToSearch (eventID) {
-    currentFilterContext.setField('eventID', [eventID], true);
+    currentFilterContext.setField('eventHierarchy', [eventID], true);
     setActiveEventID(null);
     setActiveDatasetKey(null);
   }
 
   function addEventTypeToSearch (eventID, eventType) {
-    currentFilterContext.setField('eventID', [eventID], true);
+    currentFilterContext.setField('eventHierarchy', [eventID], true);
     currentFilterContext.setField('eventType', [eventType], true);
     setActiveEventID(null);
     setActiveDatasetKey(null);


### PR DESCRIPTION
Currently, the `view events related to this ...` and the event data structure child nodes fail to update the search results, as they're updating the `eventID` query parameter, rather than `eventHierarchy`.

### Screenshots
![Screenshot 2022-12-07 at 3 59 00 pm](https://user-images.githubusercontent.com/104949733/206100692-08ed1d28-d709-4b1a-9fa3-754272e8a71a.png)

![Screenshot 2022-12-07 at 3 59 40 pm](https://user-images.githubusercontent.com/104949733/206100677-f7afdf42-a203-4a2d-85b8-98dd6f4c25a1.png)
