### PR TITLE
Fix portal crash when entering an empty `eventType` search pattern string

### DIFF
--- a/packages/react-components/src/utils/labelMaker/commonLabels.js
+++ b/packages/react-components/src/utils/labelMaker/commonLabels.js
@@ -224,7 +224,7 @@ export const commonLabels = {
   },
   identityFn: {
     type: 'TRANSFORM',
-    transform: ({ id }) => id
+    transform: ({ id }) => id.value || id
   },
   // -- Add labels above this line (required by plopfile.js) --
 }


### PR DESCRIPTION
If an empty string is provided for a pattern search on the `Event type` filter, an object is returned to the `identifyFn`'s `id` parameter (in commonLabels.js) instead of a string:

![image](https://user-images.githubusercontent.com/104949733/206324262-c6780062-c7ee-46bc-877f-e4bcb90dbb4d.png)

This crashes the portal, as objects are not valid React children. This small fix remedies this by conditionally rendering the value property of the returned object if it exists, otherwise it will just return the ID string, like so:

```js
identityFn: {
  type: 'TRANSFORM',
  transform: ({ id }) => id.value || id
}
```