### PR TITLE
Fixes Map sidebar 'view events related to this ...' button not working

### DIFF
--- a/packages/react-components/src/search/EventSearch/views/Map/MapPresentation.js
+++ b/packages/react-components/src/search/EventSearch/views/Map/MapPresentation.js
@@ -45,7 +45,7 @@ function Map({ labelMap, query, pointData, pointError, pointLoading, loading, to
   }
 
   function addToSearch (eventID) {
-    currentFilterContext.setField('eventID', [eventID], true);
+    currentFilterContext.setField('eventHierarchy', [eventID], true);
     setActiveEventID(null);
     dialog.setVisible(false)
     showList(false);


### PR DESCRIPTION
Same issue as #236 - the 'view events related to this ...' button is querying by `eventID`, not `eventHierarchy`.