### PR TITLE
Site grid display improvements for #254

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ packages/react-components/locales/dist
 .idea/
 *.log
 .history
+gbif-web.iml

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -31,6 +31,32 @@
             "type": "node"
         },        
         {
+            "name": "RUN TRANSLATIONS",
+            "request": "launch",
+            "runtimeArgs": [
+                "run", "serve-translations"
+            ],
+            "cwd": "${workspaceFolder}/packages/react-components",
+            "runtimeExecutable": "npm",
+            "skipFiles": [
+                "<node_internals>/**"
+            ],
+            "type": "node"
+        },
+        {
+            "name": "WATCH TRANSLATIONS",
+            "request": "launch",
+            "runtimeArgs": [
+                "run","watch-translations"
+            ],
+            "cwd": "${workspaceFolder}/packages/react-components",
+            "runtimeExecutable": "npm",
+            "skipFiles": [
+                "<node_internals>/**"
+            ],
+            "type": "node"
+        },
+        {
             // Name of configuration; appears in the launch configuration drop down menu.
             "name": "ES2VT",
             // Type of configuration. Possible values: "node", "mono".

--- a/packages/react-components/locales/source/en-developer/components/eventDetails.json
+++ b/packages/react-components/locales/source/en-developer/components/eventDetails.json
@@ -14,6 +14,7 @@
   "eventTypeHierarchyJoined": "Event type hierarchy",
   "eventHierarchyJoined": "Event hierarchy",
   "map": "Map of location",
+  "siteLocation": "Site location",
   "info": {
     "original": "Original",
     "excluded": "Excluded",
@@ -33,5 +34,7 @@
     "geologicalContext": "Geological context",
     "other": "Other",
     "measurementsOrFacts": "Measurements"
-  }
+  },
+  "siteTooltip": "{count} events at {site} in {date}",
+  "siteTableLegend" : "Site / Year"
 }

--- a/packages/react-components/locales/source/en-developer/components/filters.json
+++ b/packages/react-components/locales/source/en-developer/components/filters.json
@@ -225,6 +225,11 @@
     "count": "{num, plural, one { event id } other {# event ids}}",
     "description": "The unique identifier for the Event in the record."
   },
+  "eventID": {
+    "name": "Event ID",
+    "count": "{num, plural, one { event id } other {# event ids}}",
+    "description": "The unique identifier for the Event in the record."
+  },  
   "parentEventId": {
     "name": "Parent event ID",
     "count": "{num, plural, one { event id } other {# event ids}}",

--- a/packages/react-components/src/entities/EventSidebar/details/properties.js
+++ b/packages/react-components/src/entities/EventSidebar/details/properties.js
@@ -60,7 +60,7 @@ export function FacetList(props) {
   const { value } = props.term;
   if (value.length > 1) {
     const listItems = value.map(facet =>
-        <li>
+        <li key={facet.key}>
           {facet.key} ({facet.count.toLocaleString()})
         </li>
     );

--- a/packages/react-components/src/entities/SiteSidebar/SiteSidebar.js
+++ b/packages/react-components/src/entities/SiteSidebar/SiteSidebar.js
@@ -1,7 +1,7 @@
 import React, { useContext, useEffect, useState } from 'react';
 import ThemeContext from '../../style/themes/ThemeContext';
 import * as css from './styles';
-import { Row, Col, Tabs, Accordion, Properties } from "../../components";
+import { Row, Col, Tabs, Accordion, Properties, Eyebrow } from "../../components";
 import { useQuery } from '../../dataManagement/api';
 import { TabPanel } from "../../components/Tabs/Tabs";
 import { FormattedMessage } from "react-intl";
@@ -55,45 +55,62 @@ export function SiteSidebar({
         </TabList>
       </Col>
       <Col shrink={false} grow={false} css={css.detailDrawerContent({ theme })} >
-        <TabPanel tabId='details' style={{ height: '100%' }}>
-          <Row direction="column" wrap="nowrap" style={{ maxHeight: '100%', overflow: 'hidden' }}>
-            {isLoading && <Col style={{ padding: '12px', paddingBottom: 50, overflow: 'auto' }} grow>
-              <h2>Site: {siteID} - Loading information...</h2>
-              <TemporalDisplay year={year} month={month} />
-            </Col>}
-            {!isLoading && <Col style={{ padding: '12px', paddingBottom: 50, overflow: 'auto' }} grow>
-              <h2>Site: {siteID}</h2>
-              <TemporalDisplay year={year} month={month} />
-              <Group label={"eventDetails.siteLocation"}>
-                <Properties css={css.properties} breakpoint={800}>
-                  <PlainTextField term={{ simpleName: "locality", value: location?.location?.locality }} />
-                  <PlainTextField term={{ simpleName: "stateProvince", value: location?.location?.stateProvince }} />
-                  <EnumField term={{ simpleName: "country", value: location?.location?.countryCode }}
-                    label="occurrenceFieldNames.country" getEnum={value => `enums.countryCode.${value}`} />
-                  <PlainTextField term={{ simpleName: "decimalLatitude", value: location?.location?.coordinates?.lat }} />
-                  <PlainTextField term={{ simpleName: "decimalLongitude", value: location?.location?.coordinates?.lon }} />
-                </Properties>
-              </Group>
-              <Group label={"eventDetails.map"}>
-                <Map latitude={location?.location?.coordinates?.lat} longitude={location?.location?.coordinates?.lon} />
-              </Group>
-              <Summary locationID={siteID} year={year} month={month} />
-            </Col>
-            }
-          </Row>
-        </TabPanel>
+        {isLoading && (
+          <Col style={{ padding: '12px', paddingBottom: 50, overflow: 'auto' }} grow>
+            <h2>{siteID} - Loading site information...</h2>
+            <TemporalDisplay year={year} month={month} />
+          </Col>
+        )}
+            {!isLoading && (
+              <TabPanel tabId="details" style={{ height: '100%' }}>
+                <Row direction="column" wrap="nowrap" style={{ maxHeight: '100%', overflow: 'hidden' }}>
+                  <Col style={{ paddingBottom: 50, overflow: 'auto' }} grow>
+                    <Row wrap="no-wrap" css={css.header({ theme })}>
+                      <Col grow>
+                        <h1>Site: {siteID}</h1>
+                        <TemporalDisplay year={year} month={month} />
+                      </Col>
+                    </Row>
+                    <Group label={"eventDetails.siteLocation"}>
+                      <Properties css={css.properties} breakpoint={800}>
+                        <PlainTextField term={{ simpleName: "locality", value: location?.location?.locality }} />
+                        <PlainTextField term={{ simpleName: "stateProvince", value: location?.location?.stateProvince }} />
+                        <EnumField term={{ simpleName: "country", value: location?.location?.countryCode }}
+                          label="occurrenceFieldNames.country" getEnum={value => `enums.countryCode.${value}`} />
+                        <PlainTextField term={{ simpleName: "decimalLatitude", value: location?.location?.coordinates?.lat }} />
+                        <PlainTextField term={{ simpleName: "decimalLongitude", value: location?.location?.coordinates?.lon }} />
+                      </Properties>
+                    </Group>
+                    <Group label={"eventDetails.map"}>
+                      <Map latitude={location?.location?.coordinates?.lat} longitude={location?.location?.coordinates?.lon} />
+                    </Group>
+                    <Summary locationID={siteID} year={year} month={month} />
+                  </Col>
+                </Row>
+              </TabPanel>
+            )}
       </Col>
     </Row>
   </Tabs>
 };
 
 export function TemporalDisplay({ year, month }) {
-  if (year && month && month > 0){
-    return <h4>Details of activity in <FormattedMessage id={`enums.month.${month}`} defaultMessage={`${month}`} />, {year}</h4>
-  } 
-  if (year){
-    return <h4>Details of activity in {year}</h4>
+  if (year && month && month > 0) {
+    return (
+      <Eyebrow 
+        style={{fontSize: '80%'}}
+        prefix={<>Details of activity in <FormattedMessage id={`enums.month.${month}`} defaultMessage={`${month}`} />, {year}</>}
+      />
+    );
+  } else if (year) {
+    return (
+      <Eyebrow 
+        style={{fontSize: '80%'}}
+        prefix={`Details of activity in ${year}`}
+      />
+    );
   }
+  
   return null;
 }
 

--- a/packages/react-components/src/entities/SiteSidebar/SiteSidebar.js
+++ b/packages/react-components/src/entities/SiteSidebar/SiteSidebar.js
@@ -14,6 +14,8 @@ const { TabList, Tab, TapSeperator } = Tabs;
 export function SiteSidebar({
   onCloseRequest,
   siteID,
+  year,
+  month,
   className,
   style,
   ...props
@@ -32,7 +34,6 @@ export function SiteSidebar({
   useEffect(() => {
     if (!loading && location) {
       setTab('details');
-      console.log(location);
     }
   }, [data, loading]);
 
@@ -58,10 +59,12 @@ export function SiteSidebar({
           <Row direction="column" wrap="nowrap" style={{ maxHeight: '100%', overflow: 'hidden' }}>
             {isLoading && <Col style={{ padding: '12px', paddingBottom: 50, overflow: 'auto' }} grow>
               <h2>Site: {siteID} - Loading information...</h2>
+              <TemporalDisplay year={year} month={month} />
             </Col>}
             {!isLoading && <Col style={{ padding: '12px', paddingBottom: 50, overflow: 'auto' }} grow>
-              <h2> Site: {siteID} </h2>
-              <Group label={"Site location"}>
+              <h2>Site: {siteID}</h2>
+              <TemporalDisplay year={year} month={month} />
+              <Group label={"eventDetails.siteLocation"}>
                 <Properties css={css.properties} breakpoint={800}>
                   <PlainTextField term={{ simpleName: "locality", value: location?.location?.locality }} />
                   <PlainTextField term={{ simpleName: "stateProvince", value: location?.location?.stateProvince }} />
@@ -71,10 +74,10 @@ export function SiteSidebar({
                   <PlainTextField term={{ simpleName: "decimalLongitude", value: location?.location?.coordinates?.lon }} />
                 </Properties>
               </Group>
-              <Group label={"Map of site location"}>
+              <Group label={"eventDetails.map"}>
                 <Map latitude={location?.location?.coordinates?.lat} longitude={location?.location?.coordinates?.lon} />
               </Group>
-              <Summary locationID={siteID} />
+              <Summary locationID={siteID} year={year} month={month} />
             </Col>
             }
           </Row>
@@ -83,6 +86,17 @@ export function SiteSidebar({
     </Row>
   </Tabs>
 };
+
+export function TemporalDisplay({ year, month }) {
+  if (year && month && month > 0){
+    return <h4>Details of activity in <FormattedMessage id={`enums.month.${month}`} defaultMessage={`${month}`} />, {year}</h4>
+  } 
+  if (year){
+    return <h4>Details of activity in {year}</h4>
+  }
+  return null;
+}
+
 
 export function Group({ label, ...props }) {
   return <Accordion

--- a/packages/react-components/src/entities/SiteSidebar/details/Summaries.js
+++ b/packages/react-components/src/entities/SiteSidebar/details/Summaries.js
@@ -35,7 +35,8 @@ function TaxonomicCoverage({ showAll, termMap }) {
     'order',
     'class',
     'family',
-    'genus'
+    'genus',
+    'species'
   ].find(x => termMap[x]);
   if (!hasContent) return null;
 
@@ -46,7 +47,8 @@ function TaxonomicCoverage({ showAll, termMap }) {
       <FacetListInline term={termMap.class} showDetails={showAll}/>
       <FacetListInline term={termMap.order} showDetails={showAll}/>
       <FacetListInline term={termMap.family} showDetails={showAll}/>
-      <FacetListInline term={termMap.genus} showDetails={showAll}/>
+      <FacetListInline term={termMap.genus} showDetails={showAll} style={{ fontStyle: "italic" }}/>
+      <FacetListInline term={termMap.species} showDetails={showAll} style={{ fontStyle: "italic" }}/>
     </Properties>
   </Group>
 }

--- a/packages/react-components/src/entities/SiteSidebar/details/Summary.js
+++ b/packages/react-components/src/entities/SiteSidebar/details/Summary.js
@@ -5,6 +5,8 @@ import {Summaries} from "./Summaries";
 
 export function Summary({
   locationID,
+  year,
+  month,
   ...props
 }) {
   const theme = useContext(ThemeContext);
@@ -13,11 +15,35 @@ export function Summary({
 
   useEffect(() => {
     if (typeof locationID !== 'undefined') {
-      const predicate = {
-          key:  "locationID",
-          type: "equals",
-          value: locationID
+      
+      const singlePredicate = {
+          key:  "locationID", type: "equals", value: locationID
       }
+
+      const predicateYear = {
+        type: 'and',
+        predicates: [
+          { key:  "locationID", type: "equals", value: locationID},
+          { key:  "year", type: "equals", value: year}
+        ]
+      }        
+
+      const predicateYearMonth = {
+        type: 'and',
+        predicates: [
+          { key:  "locationID", type: "equals", value: locationID},
+          { key:  "year", type: "equals", value: year},
+          { key:  "month", type: "equals", value: month}
+        ]
+      }      
+
+      let predicate = singlePredicate;
+      if (month >= 0){
+        predicate = predicateYearMonth;
+      } else if (year){
+        predicate = predicateYear;
+      }
+
       load({ keepDataWhileLoading: true, variables: { predicate, size: 0, from: 0 } });
     }
   }, [locationID]);
@@ -30,7 +56,7 @@ export function Summary({
 const FACET_BREAKDOWN = `
 query list($predicate: Predicate, $offset: Int, $limit: Int){
   results: eventSearch(
-    predicate:$predicate,
+    predicate: $predicate,
     size: $limit, 
     from: $offset
     ) {
@@ -84,7 +110,11 @@ query list($predicate: Predicate, $offset: Int, $limit: Int){
       genus {
         count
         key
-      }      
+      }  
+      species {
+        count
+        key
+      }            
       samplingProtocol {
         count
         key

--- a/packages/react-components/src/entities/SiteSidebar/styles.js
+++ b/packages/react-components/src/entities/SiteSidebar/styles.js
@@ -34,6 +34,7 @@ export const entitySummary = ({ ...props }) => css`
 
 export const header = ({ ...props }) => css`
   margin: 0 16px;
+  padding-bottom: 16px;
   .gbif-header-location {
     font-size: 13px;
     display: flex;

--- a/packages/react-components/src/search/EventSearch/views/Sites/SitesTable.js
+++ b/packages/react-components/src/search/EventSearch/views/Sites/SitesTable.js
@@ -6,20 +6,20 @@ import {Skeleton} from "../../../../components";
 import { FormattedMessage } from "react-intl";
 
 function SitesTableSkeleton() {
-      return <div className={`grid-container`}>
-        <div className={`grid`}>
-          <div className={`legend`}>
+      return <div className="grid-container">
+        <div className="grid">
+          <div className="legend">
             <Skeleton width="random" />
           </div>
-          <div className={`header`}>
+          <div className="header">
             <Skeleton width="random" style={{ height: '1.5em' }} />
           </div>
-          <div className={`sideBar`}>
+          <div className="sideBar">
             <Skeleton width="random" />
             <Skeleton width="random" />
             <Skeleton width="random" />
           </div>
-          <div className={`main-grid`}>
+          <div className="main-grid">
             <Skeleton width="random" />
             <Skeleton width="random" />
             <Skeleton width="random" />
@@ -130,22 +130,22 @@ export const SitesTable = ({ first, prev, next, size, from, results, loading, se
       <DataTable fixedColumn={fixed} {...{ first, prev, next, size, from, total: totalPoints, loading }} style={{ flex: "1 1 auto", height: 100, display: 'flex', flexDirection: 'column' }}>
         <tbody>
           <tr css={ styles.sites({ noOfSites: siteMatrix.length, noOfYears: years.length, showMonth: showMonth, theme }) }>
-            <td className={`grid-container`}>
-              <div className={`grid`}>
-                <div className={`legend`}> 
+            <td className="grid-container">
+              <div className="grid">
+                <div className="legend"> 
                   <FormattedMessage id="eventDetails.siteTableLegend"/>
                 </div>
-                <div className={`header`}>
-                  <div className={`header-grid`}>  
+                <div className="header">
+                  <div className="header-grid">  
                     { years.map(obj => <ul><li key={`y_${obj}`}>{obj}</li></ul>) }
                   </div>                     
                 </div>
-                <div className={`sidebar`}>
-                  <div className={`sidebar-grid`}>   
+                <div className="sideBar">
+                  <div className="sidebar-grid">   
                    { siteData.map( (obj, i) => <ul><li key={`s_${i}`} onClick={() => { setSiteIDCallback({locationID: obj.key}); }}>{obj.key}</li></ul>) }
                   </div>
                 </div>
-                <div className={`main-grid`}>
+                <div className="main-grid">
                   <SitesDataGrid siteMatrix={siteMatrix} siteData={siteData} years={years} setSiteIDCallback={setSiteIDCallback} showMonth={showMonth} />
                 </div>
               </div>
@@ -158,11 +158,11 @@ export const SitesTable = ({ first, prev, next, size, from, results, loading, se
 
 export const SitesDataGrid = ({ siteMatrix, siteData, years, setSiteIDCallback, showMonth }) => {
 
-  return <div className={`data-grid`}>              
+  return <div className="data-grid">              
   {
     siteMatrix.map( (siteRow, site_idx) => 
       siteRow.map( (year_cell, year_idx) => 
-        <ul className={`year-grid`} key={`${site_idx}_${year_idx}`}>
+        <ul className="year-grid" key={`${site_idx}_${year_idx}`}>
           {   
             year_cell.map( (month_cell, month_idx) =>
                 <li className={`${month_idx}_col`}
@@ -190,8 +190,8 @@ export const SitesDataGrid = ({ siteMatrix, siteData, years, setSiteIDCallback, 
 
 export const SitesDataGridTooltip = ({ month_cell, month_idx, site_id, year, showMonth }) => {
   if (month_cell > 0 ){
-    return <span className={`tooltiptext`}>
-      <FormattedMessage id={"eventDetails.siteTooltip"} 
+    return <span className="tooltiptext">
+      <FormattedMessage id="eventDetails.siteTooltip" 
           values={ {count: month_cell, site: site_id, date: ((showMonth ? ((month_idx + 1) + '/') : '') + year) } }  />
       </span>;  
   }

--- a/packages/react-components/src/search/EventSearch/views/Sites/SitesTable.js
+++ b/packages/react-components/src/search/EventSearch/views/Sites/SitesTable.js
@@ -1,158 +1,201 @@
 import React, {useContext, useEffect, useState} from "react";
 import styles from './styles';
 import ThemeContext from "../../../../style/themes/ThemeContext";
-import {Button, DataTable, Skeleton} from "../../../../components";
-import {ResultsHeader} from "../../../ResultsHeader";
-import {css} from "@emotion/react";
-import * as style from "../List/style";
+import {DataTable} from "../../../../components";
+import {Skeleton} from "../../../../components";
+import { FormattedMessage } from "react-intl";
 
-function SitesSkeleton() {
-  return <div css={style.datasetSkeleton}>
-    <Skeleton width="random" style={{ height: '1.5em' }} />
-    <Skeleton width="random" />
-    <Skeleton width="random" />
-    <Skeleton width="random" />
-  </div>
+function SitesTableSkeleton() {
+      return <div className={`grid-container`}>
+        <div className={`grid`}>
+          <div className={`legend`}>
+            <Skeleton width="random" />
+          </div>
+          <div className={`header`}>
+            <Skeleton width="random" style={{ height: '1.5em' }} />
+          </div>
+          <div className={`sideBar`}>
+            <Skeleton width="random" />
+            <Skeleton width="random" />
+            <Skeleton width="random" />
+          </div>
+          <div className={`main-grid`}>
+            <Skeleton width="random" />
+            <Skeleton width="random" />
+            <Skeleton width="random" />
+          </div>
+      </div>
+    </div>
 }
 
-export const SitesTable = ({ first, prev, next, size, from, results, total, loading, setSiteIDCallback }) => {
+export const SitesTable = ({ first, prev, next, size, from, results, loading, setSiteIDCallback, showMonth }) => {
 
   const theme = useContext(ThemeContext);
   const [fixedColumn, setFixed] = useState(true);
   const fixed = fixedColumn;
+  const [siteMatrix, setSiteMatrix] = useState(null);  
+  const [siteData, setSiteData] = useState(null);  
+  const [years, setYears] = useState([]);  
+  const [totalPoints, setTotalPoints] = useState([]);  
 
-  const [activeSiteID, setActiveSiteID] = useState(false);
-  const [showMonth, setShowMonth] = useState(true);
+  Array.range = (start, end) => Array.from({length: (end + 1 - start)}, (v, k) => k + start);
 
-  const toggle = () => {
-    setShowMonth(!showMonth);
-    renderMatrix();
-  }
+  function renderMatrix(){
 
-  Array.range = (start, end) => Array.from({length: (end - start)}, (v, k) => k + start);
-
-  useEffect(() => {
-    if (activeSiteID) {
-      setSiteIDCallback(activeSiteID)
-    }
-  }, [activeSiteID]);
-
-  // current result set
-  const items = results;
-
-  let site_data = [];
-  let no_of_sites = 0;
-  let no_of_years = 0;
-  let years = [];
-  let no_of_squares_in_row =0;
-  let total_no_points = 0;
-
-  // columns are months  by  rows are sites,
-  let site_matrix = [];
-
-  const renderMatrix = () => {
+    setYears([]);
+    setSiteMatrix([]);
+    setSiteData([]);
+    setTotalPoints(0);
+    
+    let items = results;
     if (items && items.results?.temporal?.locationID?.results){
-      site_data = items.results.temporal.locationID?.results;
-      no_of_sites = site_data.length;
 
+      let site_data = items.results.temporal.locationID?.results;
       let all_years = [];
       site_data.map(obj => obj.breakdown).forEach( breakdown => {
-            breakdown.forEach( yearGroup => {
-              all_years.push(yearGroup.y);
-            })
-          }
+          breakdown.forEach( yearGroup => {
+            all_years.push(yearGroup.y);
+          })
+        }
       )
 
       let earliest_year = Math.min(...all_years);
       let latest_year = Math.max(...all_years);
+      let year_range = [];
+      if (earliest_year == latest_year){
+        year_range = [earliest_year];
+      } else {
+        year_range = Array.range(earliest_year, latest_year);
+      }
 
-      years = Array.range(earliest_year, latest_year);
+      let no_of_squares_in_row = year_range.length * 12;
+      let total_no_points = no_of_squares_in_row * site_data.length;
 
-      no_of_years = years.length;
-      no_of_squares_in_row = no_of_years * 12;
-      total_no_points = no_of_squares_in_row * no_of_sites
-      site_matrix = new Array(years.length * 12).fill(0).map(() => new Array(no_of_sites).fill(0));
-
+      // build 3d array site_matrix[site][year][month]
+      let  site_matrix = new Array(site_data.length);
+      for (var i = 0; i < site_matrix.length; i++){
+          var years_arr = new Array(year_range.length);
+          for (var j = 0; j < year_range.length; j++){
+             if (showMonth){
+              years_arr[j] = new Array(12).fill(0);
+             } else {
+              years_arr[j] = new Array(1).fill(0);
+             }
+          }
+          site_matrix[i] = years_arr;
+      }
+      
       site_data.forEach( (site, site_index) => {
 
-        //row per site
-        years.forEach( (year, year_idx) => {
+        // row per site
+        year_range.forEach( (year, year_idx) => {
+ 
           // get the data for the year
           let yearBreakdown = site.breakdown.filter( breakdown => breakdown.y == year);
           if (yearBreakdown && yearBreakdown.length == 1) {
-            if (yearBreakdown[0].ms) {
-              if (showMonth) {
-                yearBreakdown[0].ms.forEach(month => {
-                  site_matrix[(month.m - 1) + (year_idx * 12)][site_index] = month.c;
-                });
-              } else {
-
-                let total = 0;
-                yearBreakdown[0].ms.forEach(month => {
-                  total = total + month.c;
-                });
-
-                [...Array(12).keys()].forEach(month => {
-                      site_matrix[month + (year_idx * 12)][site_index] = total;
-                    }
+            if (showMonth) {
+              if (yearBreakdown[0].ms) {
+                yearBreakdown[0].ms.forEach(ms_month => 
+                  site_matrix[site_index][year_idx][ms_month.m - 1] = ms_month.c 
                 );
               }
+            } else {
+              site_matrix[site_index][year_idx] = [yearBreakdown[0].c];
             }
           }
         })
       })
+
+      setYears(year_range);
+      setSiteMatrix(site_matrix);
+      setSiteData(site_data);
+      setTotalPoints(total_no_points);
     }
   }
 
-  renderMatrix();
+  useEffect(() => {
+    renderMatrix();
+  }, [showMonth]);
 
-  if (no_of_sites == 0){
+
+  if (!results.results.temporal.locationID?.results || results.results.temporal.locationID?.results.length == 0){
     return <><div>No site data available</div></>
   }
 
+  if (!siteMatrix || siteMatrix.length == 0){
+    return <SitesTableSkeleton />
+  }
+
   return <>
-    <div style={{
-      flex: "1 1 100%",
-      display: "flex",
-      height: "100%",
-      maxHeight: "100vh",
-      flexDirection: "column",
-    }}>
-      <ResultsHeader loading={loading} total={total}>
-          <Button onClick={() => toggle()} look="primaryOutline" css={css`margin-left: 30px; font-size: 11px;`}>Show year / month</Button>
-      </ResultsHeader>
-      <DataTable fixedColumn={fixed} {...{ first, prev, next, size, from, total: total_no_points, loading }} style={{ flex: "1 1 auto", height: 100, display: 'flex', flexDirection: 'column' }}>
+      <DataTable fixedColumn={fixed} {...{ first, prev, next, size, from, total: totalPoints, loading }} style={{ flex: "1 1 auto", height: 100, display: 'flex', flexDirection: 'column' }}>
         <tbody>
-        <tr  css={ styles.sites({ noOfSites: no_of_sites, noOfYears: no_of_years, showMonth: showMonth, theme }) }>
-          <td className={`graph`} >
-            <ul className={`time`}>
-              { years.map(obj => <li key={`y_${obj}`}>{obj}</li>) }
-            </ul>
-            <ul className={`sites`}>
-              { site_data.map( (obj, i) => <li key={`s_${i}`} onClick={() => { setActiveSiteID(obj.key); }}>{obj.key}</li>) }
-            </ul>
-            <ul className={`squares`}>
-              {
-                site_matrix.map( (month_column, c_idx) =>
-                    month_column.map( (square, ce_idx) =>
-                            <li className={`${c_idx % 12}_col`}
-                                id={`${c_idx}_${ce_idx}`}
-                                key={`${c_idx}_${ce_idx}`}
-                                data-level={ square > 0 ? '3': '0'}
-                                onClick={() => { setActiveSiteID(site_data[ce_idx].key); }}
-                            >
-                              { square > 0 && <span className={`tooltiptext`}>{ square } events</span> }
-                            </li>
-                    )
-                )
-              }
-            </ul>
-          </td>
-        </tr>
+          <tr css={ styles.sites({ noOfSites: siteMatrix.length, noOfYears: years.length, showMonth: showMonth, theme }) }>
+            <td className={`grid-container`}>
+              <div className={`grid`}>
+                <div className={`legend`}> 
+                  <FormattedMessage id="eventDetails.siteTableLegend"/>
+                </div>
+                <div className={`header`}>
+                  <div className={`header-grid`}>  
+                    { years.map(obj => <ul><li key={`y_${obj}`}>{obj}</li></ul>) }
+                  </div>                     
+                </div>
+                <div className={`sidebar`}>
+                  <div className={`sidebar-grid`}>   
+                   { siteData.map( (obj, i) => <ul><li key={`s_${i}`} onClick={() => { setSiteIDCallback({locationID: obj.key}); }}>{obj.key}</li></ul>) }
+                  </div>
+                </div>
+                <div className={`main-grid`}>
+                  <SitesDataGrid siteMatrix={siteMatrix} siteData={siteData} years={years} setSiteIDCallback={setSiteIDCallback} showMonth={showMonth} />
+                </div>
+              </div>
+            </td>
+          </tr>
         </tbody>
       </DataTable>
-    </div>
   </>
+}
+
+export const SitesDataGrid = ({ siteMatrix, siteData, years, setSiteIDCallback, showMonth }) => {
+
+  return <div className={`data-grid`}>              
+  {
+    siteMatrix.map( (siteRow, site_idx) => 
+      siteRow.map( (year_cell, year_idx) => 
+        <ul className={`year-grid`} key={`${site_idx}_${year_idx}`}>
+          {   
+            year_cell.map( (month_cell, month_idx) =>
+                <li className={`${month_idx}_col`}
+                    id={`${site_idx}_${year_idx}_${month_idx}`}
+                    key={`${site_idx}_${year_idx}_${month_idx}`}
+                    data-level={ month_cell > 0 ? '3': '0'}
+                    onClick={() => { setSiteIDCallback({locationID: siteData[site_idx].key, year: years[year_idx], month: showMonth ? month_idx + 1 : -1}); }}
+                >
+                  <SitesDataGridTooltip 
+                      key={`${site_idx}_${year_idx}_${month_idx}_tt`}
+                      month_cell={month_cell} 
+                      month_idx={month_idx}
+                      site_id={siteData[site_idx].key} 
+                      year={years[year_idx]} 
+                      showMonth={showMonth} />
+                </li>
+            )
+          }
+        </ul>  
+      )
+    )
+  }
+  </div>
+}
+
+export const SitesDataGridTooltip = ({ month_cell, month_idx, site_id, year, showMonth }) => {
+  if (month_cell > 0 ){
+    return <span className={`tooltiptext`}>
+      <FormattedMessage id={"eventDetails.siteTooltip"} 
+          values={ {count: month_cell, site: site_id, date: ((showMonth ? ((month_idx + 1) + '/') : '') + year) } }  />
+      </span>;  
+  }
+  return null;
 }
 
 export default SitesTable;

--- a/packages/react-components/src/search/EventSearch/views/Sites/index.js
+++ b/packages/react-components/src/search/EventSearch/views/Sites/index.js
@@ -48,7 +48,7 @@ function SitesSkeleton() {
       flexDirection: "column"
     }}>
       <ResultsHeader>
-          <Button look="primaryOutline" css={css`margin-left: 30px; font-size: 11px;`}>
+          <Button look="primaryOutline" css={css`margin-left: 30px; font-size: 11px;`} disabled>
             Show year / month
           </Button>
       </ResultsHeader>    

--- a/packages/react-components/src/search/EventSearch/views/Sites/index.js
+++ b/packages/react-components/src/search/EventSearch/views/Sites/index.js
@@ -10,7 +10,9 @@ import {useUpdateEffect} from "react-use";
 import {DetailsDrawer, Skeleton} from "../../../../components";
 import {SiteSidebar} from "../../../../entities/SiteSidebar/SiteSidebar";
 import {useDialogState} from "reakit/Dialog";
-import * as style from "../List/style";
+import {ResultsHeader} from "../../../ResultsHeader";
+import {Button} from "../../../../components";
+import {css} from "@emotion/react";
 
 const QUERY = `
 query list( $predicate: Predicate, $size: Int = 20, $from: Int = 0){
@@ -38,11 +40,40 @@ query list( $predicate: Predicate, $size: Int = 20, $from: Int = 0){
 `;
 
 function SitesSkeleton() {
-  return <div css={style.datasetSkeleton}>
-    <Skeleton width="random" style={{ height: '1.5em' }} />
-    <Skeleton width="random" />
-    <Skeleton width="random" />
-    <Skeleton width="random" />
+  return <div style={{
+      flex: "1 1 100%",
+      display: "flex",
+      height: "100%",
+      maxHeight: "100vh",
+      flexDirection: "column"
+    }}>
+      <ResultsHeader>
+          <Button look="primaryOutline" css={css`margin-left: 30px; font-size: 11px;`}>
+            Show year / month
+          </Button>
+      </ResultsHeader>    
+
+      
+      <div className={`grid-container`}>
+        <div className={`grid`}>
+          <div className={`legend`}>
+            <Skeleton width="random" />
+          </div>
+          <div className={`header`}>
+            <Skeleton width="random" style={{ height: '1.5em' }} />
+          </div>
+          <div className={`sideBar`}>
+            <Skeleton width="random" />
+            <Skeleton width="random" />
+            <Skeleton width="random" />
+          </div>
+          <div className={`main-grid`}>
+            <Skeleton width="random" />
+            <Skeleton width="random" />
+            <Skeleton width="random" />
+          </div>
+        </div>
+    </div>
   </div>
 }
 
@@ -52,8 +83,11 @@ function Sites() {
   const currentFilterContext = useContext(FilterContext);
   const { rootPredicate, predicateConfig } = useContext(SearchContext);
   const { data, error, loading, load } = useQuery(QUERY, { lazyLoad: true, throwNetworkErrors: true, queryTag: 'sites' });
-
   const [activeSiteID, setActiveSiteID] = useState(false);
+  const [activeYear, setActiveYear] = useState(false);
+  const [activeMonth, setActiveMonth] = useState(false);
+
+  const [showMonth, setShowMonth] = useState(true);
 
   const dialog = useDialogState({ animated: true, modal: false });
 
@@ -94,6 +128,8 @@ function Sites() {
   useUpdateEffect(() => {
     if (!dialog.visible) {
       setActiveSiteID(null);
+      setActiveYear(null); 
+      setActiveMonth(null);       
     }
   }, [dialog.visible]);
 
@@ -110,6 +146,24 @@ function Sites() {
     setOffset(undefined);
   });
 
+  const toggleMonthYearDisplay = useCallback(() => {
+    setShowMonth(!showMonth);
+  });
+
+  const closeSidebar = () => {
+    setActiveSiteID(null); 
+    setActiveYear(null); 
+    setActiveMonth(null); 
+    dialog.setVisible(false);
+  }
+
+  const setSiteIDCallback = ({locationID, year, month}) => {
+    setActiveSiteID(locationID);
+    setActiveYear(year);
+    setActiveMonth(month);
+  }
+
+
   if (error) {
     return <div>Failed to fetch data</div>
   }
@@ -120,23 +174,38 @@ function Sites() {
     <DetailsDrawer href={`${activeSiteID}`} dialog={dialog}>
       <SiteSidebar
           siteID={activeSiteID}
+          year={activeYear}
+          month={activeMonth}
           defaultTab='details'
           style={{ maxWidth: '100%', width: 700, height: '100%' }}
-          onCloseRequest={() => dialog.setVisible(false)}
+          onCloseRequest={() => closeSidebar()}
       />
     </DetailsDrawer>
-    <SitesTable
-        error={error}
-        loading={loading}
-        next={next}
-        prev={prev}
-        first={first}
-        from={offset}
-        size={limit}
-        results={data}
-        total={data?.results?.temporal?.locationID?.cardinality}
-        setSiteIDCallback={ setActiveSiteID }
-    />
+    <div style={{
+      flex: "1 1 100%",
+      display: "flex",
+      height: "100%",
+      maxHeight: "100vh",
+      flexDirection: "column"
+    }}>
+      <ResultsHeader loading={loading} total={data?.results?.temporal?.locationID?.cardinality}>
+          <Button onClick={() => toggleMonthYearDisplay()} look="primaryOutline" css={css`margin-left: 30px; font-size: 11px;`}>
+            Show year / month
+          </Button>
+      </ResultsHeader>
+      <SitesTable
+          error={error}
+          loading={loading}
+          next={next}
+          prev={prev}
+          first={first}
+          from={offset}
+          size={limit}
+          results={data}
+          setSiteIDCallback={ setSiteIDCallback }
+          showMonth={showMonth}
+      />
+    </div>
   </>
 }
 

--- a/packages/react-components/src/search/EventSearch/views/Sites/styles.js
+++ b/packages/react-components/src/search/EventSearch/views/Sites/styles.js
@@ -1,104 +1,169 @@
 import { css } from '@emotion/react';
 
-export const sites = ({ noOfSites= 10, noOfYears, showMonth, theme, ...props }) => css`
+export const sites = ({ noOfSites=10, noOfYears=10, showMonth, theme, ...props }) => css`
 
-    .graph {
-      background-color: white;   
-      --square-size: ${showMonth ? '15px;' : '15px'}; ;
-      --square-width: ${showMonth ? '5px;' : '  3px'};
-      --square-height: 15px;
-      --square-gap-width: ${showMonth ? '3px' : '0px'};
-      --square-gap-height: 3px;
-      --month-width: calc(var(--square-width) + var(--square-gap-width));
-      --year-width: calc(var(--month-width) * 12)
-    }
+.grid-container {
+  padding: 0;
+  margin: 0;
+}
 
-    .time { grid-area: months; list-style-type: none; padding-left:10px;}
-    .sites { grid-area: days; list-style-type: none; list-style-position: outside; }
-    .squares { grid-area: squares; list-style-type: none;}
-    
-    .sites li {
-       white-space:nowrap;
-    }
-    
-    .sites li:hover {
-       cursor:pointer;
-    }    
-    
-    .sites {
-       padding-inline-start: 20px;
-       display:inline-block;
-    }    
-        
-    .graph {
-      display: inline-grid;
-      grid-template-areas: "empty months"
-                           "days squares";
-      grid-template-columns: auto 1fr;
-      grid-gap: 0px;
-      padding: 0px;
-    }
-    
-    .time {
-      margin-bottom: 5px;
-      display: grid;
-      grid-template-columns: repeat(${noOfYears}, var(--year-width));
-    }
-    
-    .sites,
-    .squares {
-      margin-top: 2px; 
-      display: grid;
-      grid-gap: var(--square-gap-height) var(--square-gap-width);
-      grid-template-rows: repeat(${noOfSites}, var(--square-size));
-    }
-    
-    .squares {
-      padding-left:10px;
-      grid-auto-flow: column;
-      grid-auto-columns: var(--square-width);
-    }
-    
-    .squares li {
-      background-color: #ebedf0;
-    }
-    
-    .squares li[data-level="1"] {
-      background-color: #c6e48b;
-    }
-    
-    .squares li[data-level="2"] {
-      background-color: #7bc96f;
-    }
-    
-    .squares li[data-level="3"] {
-      background-color: #196127;
-    }
-    
-    .squares li  {
-      position: relative;
-      display: inline-block;
-    }
-    
-    .squares li  .tooltiptext {
-      visibility: hidden;
-      filter: alpha(opacity=50);
-      opacity: 0.5;
-      width: 90px;
-      background-color:  #196127;
-      color: #fff;
-      text-align: center;
-      border-radius: 6px;
-      padding: 5px 0;
-      position: absolute;
-      z-index: 1;
-      margin-top: -28px;
-    }
-    
-    .squares li:hover .tooltiptext {
-      visibility: visible;
-    }    
-    
+.grid {
+  display: inline-grid;
+  grid-template-areas: "legend header"
+    "sidebar main-grid";
+  grid-template-columns: 150px auto;
+  grid-column-gap: 0px;
+}
+
+.header {
+  grid-area: header;
+  position: sticky;
+  top: 0;
+  left: 0;
+  z-index: 5;    
+  align-self: start;
+  background-color: #FFF;  
+  padding-bottom: 5px; 
+}
+
+.header ul {
+  list-style-type: none; 
+}
+
+.header li {
+  display: inline-block;
+}
+
+.sidebar {
+  grid-area: sidebar;
+  list-style-type: none; 
+  list-style-position: outside;  
+  display: inline-block;  
+  position: sticky;
+  left: 0;
+  z-index: 2;  
+  background-color: #FFF;
+  padding-left: 5px;
+}
+
+.legend {
+  grid-area: legend;
+  padding: 15px 5px 5px 10px; 
+  position: sticky;
+  top: 0;
+  left: 0;
+  z-index: 6;
+  background-color: #FFF;
+  align-self: start;
+}
+
+.main-grid {
+  grid-area: main-grid;
+}
+
+.header-grid {
+  display: grid;
+  grid-template-columns: repeat(${noOfYears}, ${showMonth ? '150px': '16px'} );
+  grid-column-gap: 0px;
+  padding: 15px 5px 5px 5px;
+}
+
+.header-grid ul {
+  list-style-type: none; 
+  margin: 0;
+  padding: 0;
+}
+
+.header-grid li {
+  display: inline-block;
+  -webkit-transform: rotate(${showMonth ? '0deg' :  '-60deg'}); 
+  -moz-transform: rotate(${showMonth ? '0deg' :  '-60deg'});   
+}
+
+.sidebar-grid {
+  display: grid;
+  grid-template-columns: repeat(1, 150px);
+  grid-column-gap: 0px;
+  padding: 5px;
+}
+
+.sidebar-grid ul {
+  list-style-type: none; 
+  margin: 0;
+  padding: 0 0 3px 0;
+  line-height: 18px;
+}
+
+.sidebar-grid li {
+  display: inline-block;
+
+}
+
+.sidebar-grid li:hover { cursor: pointer; }
+
+.data-grid {
+  display: grid;
+  grid-template-columns: repeat(${noOfYears}, ${showMonth ? '150px': '16px'});
+  grid-column-gap: 0;
+  padding: 5px;
+  grid-auto-columns: 3px;  
+}
+
+.year-grid {
+  --square-width: 3px;
+  --square-height: 18px;
+  --square-gap-width: 3px;
+  --square-gap-height: 5px; 
+  display: grid;
+  grid-template-columns: repeat(12, ${showMonth ? '9px': '14px'});
+  padding: 0 0 3px 0;
+  list-style-type: none;
+  margin: 0;
+  grid-gap: var(--square-gap-height) var(--square-gap-width);
+  grid-template-rows: repeat(1, var(--square-height));
+}
+
+.year-grid li {
+  background-color: #ebedf0;
+  display: inline-block;
+  position: relative;
+  border: 1px solid #A9A9A9;  
+}
+
+.year-grid li[data-level="1"] {
+  background-color: ${theme.primary};
+  cursor: pointer;
+}
+
+.year-grid li[data-level="2"] {
+  background-color: ${theme.primary};
+  cursor: pointer;
+}
+
+.year-grid li[data-level="3"] {
+  background-color: ${theme.primary};
+  cursor: pointer;
+}
+
+.year-grid li .tooltiptext {
+  visibility: hidden;
+  filter: alpha(opacity=80);
+  opacity: 0.8;
+  width: 90px;
+  background-color: ${theme.primary};
+  color: #fff;
+  text-align: center;
+  border-radius: 6px;
+  padding: 5px 0;
+  position: absolute;
+  z-index: 1;
+  margin-top: -48px;
+}
+
+.year-grid li:hover .tooltiptext {
+  visibility: visible;
+} 
+
 `;
 
 export default {

--- a/packages/react-components/src/search/EventSearch/views/Table/EventsTable.js
+++ b/packages/react-components/src/search/EventSearch/views/Table/EventsTable.js
@@ -157,7 +157,7 @@ const getRows = ({ tableConfig, labelMap, results = [], setActiveEventID, setAct
         return <Td noWrap={field.noWrap} key={field.trKey} style={field.value.rightAlign ? { textAlign: 'right' } : {}}>{formattedVal}</Td>;
       }
     );
-    return <tr key={row.eventID} onClick={() => {
+    return <tr key={row.eventID} style={{cursor: 'pointer'}} onClick={() => {
       let selection = window.getSelection();
       if (selection.type !== "Range") {
         setActiveEventID(row.eventID);

--- a/packages/react-components/src/search/OccurrenceSearch/config/tableConfig.js
+++ b/packages/react-components/src/search/OccurrenceSearch/config/tableConfig.js
@@ -244,5 +244,3 @@ export const tableConfig = {
     },
   ]
 };
-
-console.log(tableConfig.columns.map(x => x.name));


### PR DESCRIPTION
Changes include:
* Space between years to make it easier to see patterns of site visits
* a more condensed year by year view
* sticky sidebar, legend and header
* clicking on a month will show a breakdown for the site for this month, similarly a year
* taxonomic breakdown additions

