### PR TITLE
#280 support multi-configs

### DIFF
--- a/packages/react-components/.storybook/main.js
+++ b/packages/react-components/.storybook/main.js
@@ -1,4 +1,21 @@
+const path = require('path');
+const fs = require('fs')
+
+let envFile = path.resolve(__dirname, `../.env.${process.env.NODE_ENV}.json`);
+if (!fs.existsSync(envFile)) {
+  console.warn("Cannot find env file: "+ envFile );
+  envFile = path.resolve(__dirname, "../.env.json");
+}
+console.log("Storybook starts with env: " + envFile);
+
 module.exports = {
   stories: ['../intro/**/*.stories.js', '../src/**/*.stories.js'],
   addons: ['@storybook/addon-knobs', '@storybook/addon-actions', '@storybook/addon-links', '@storybook/addon-a11y/register', '@storybook/addon-storysource'],
+  webpackFinal: async (config, { configType }) => {
+    config.resolve.alias = {
+      ...config.resolve.alias,
+      'Env': envFile,
+    };
+    return config;
+  }
 };

--- a/packages/react-components/.storybook/preview.js
+++ b/packages/react-components/.storybook/preview.js
@@ -10,7 +10,7 @@ import { Root } from '../src/components';
 import ThemeContext, { darkTheme, lightTheme, a11yTheme, vertnetTheme, rtlTheme, alaTheme, gbifTheme } from '../src/style/themes';
 import ThemeBuilder from '../src/style/themeBuilder';
 import { ApiContext, ApiClient } from '../src/dataManagement/api';
-import env from '../.env.json';
+import env from 'Env';
 import RouteContext from '../src/dataManagement/RouteContext';
 import SiteContext from '../src/dataManagement/SiteContext';
 import { siteConfig } from './siteConfig';

--- a/packages/react-components/.storybook/siteConfig.js
+++ b/packages/react-components/.storybook/siteConfig.js
@@ -1,4 +1,4 @@
-import env from '../.env.json';
+import env from 'Env';
 
 const routeConfig = {
   occurrenceSearch: {

--- a/packages/react-components/gulpfile.js
+++ b/packages/react-components/gulpfile.js
@@ -2,7 +2,7 @@ const { src, dest, parallel } = require('gulp');
 const replace = require('gulp-replace');
 const gulpif = require('gulp-if');
 const md5File = require('md5-file');
-const env = require('./.env.json');
+const env = require('Env');
 
 // we don't really care to index our storybook
 function noIndex() {

--- a/packages/react-components/locales/build.js
+++ b/packages/react-components/locales/build.js
@@ -1,5 +1,18 @@
-const env = require('../.env.json');
+const path = require('path');
+const fs = require("fs");
+console.log("build locales: " + process.env.NODE_ENV )
+
+let envFile = path.resolve(__dirname, "../.env.json");
+if (typeof process.env.NODE_ENV !== 'undefined') {
+    envFile = path.resolve(__dirname, `../.env.${process.env.NODE_ENV}.json`);
+    if (!fs.existsSync(envFile)) {
+        console.log("Cannot find env file: "+ envFile );
+        envFile = path.resolve(__dirname, "../.env.json");
+    }
+}
+console.log("Using env: " + envFile);
+
+const env = require(envFile);
 const locales = env.LOCALES;
 const build = require('./scripts/build');
-
-build(locales);
+build(locales, env);

--- a/packages/react-components/locales/scripts/build.js
+++ b/packages/react-components/locales/scripts/build.js
@@ -7,11 +7,11 @@ const localeMaps = require('./localeMaps');
 const fs = require('fs');
 const _ = require('lodash');
 const hash = require('object-hash');
-const env = require('../../.env.json');
+
 
 module.exports = build;
 
-function build(locales) {
+function build(locales, env) {
   const targetDirectory = path.normalize(__dirname + '/../dist/');
   ensureDirectoryExistence(targetDirectory + 'translation.json');
 

--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -11,11 +11,11 @@
   },
   "scripts": {
     "build": "npx webpack --mode=production",
-    "develop": "npx webpack --mode=development --watch",
+    "build:test": "npx webpack --mode=development",
     "test": "echo \"Error: no test specified\" && exit 1",
     "serve-translations": "npx serve locales/dist/ -p 5002 --cors",
     "watch-translations": "npx nodemon locales/build.js -w locales/ -i locales/dist/",
-    "start": "node locales/build.js; start-storybook -p 6006;",
+    "start": "cross-env NODE_ENV=development node locales/build.js; start-storybook -p 6006;",
     "build-storybook": "npm run build-locales; build-storybook -o ./dist",
     "build-client": "npm run build-locales; npm run build-storybook; npm run build; npx gulp; npx gzipper compress --brotli --include js,css,html,txt,json,map ./dist",
     "build-locales": "node locales/build",

--- a/packages/react-components/src/StandaloneWrapper.js
+++ b/packages/react-components/src/StandaloneWrapper.js
@@ -10,7 +10,7 @@ import ThemeContext, { lightTheme } from './style/themes';
 import { ApiContext, ApiClient } from './dataManagement/api';
 import RouteContext, { defaultContext } from './dataManagement/RouteContext';
 import SiteContext from './dataManagement/SiteContext';
-import env from '../.env.json';
+import env from 'Env';
 
 const client = new ApiClient({
   gql: {

--- a/packages/react-components/src/components/OccurrenceMap/test/MapboxMap.js
+++ b/packages/react-components/src/components/OccurrenceMap/test/MapboxMap.js
@@ -1,7 +1,7 @@
 import React, { Component } from "react";
 import mapboxgl from 'mapbox-gl';
 import { getLayerConfig } from './getLayerConfig';
-import env from '../../../../.env.json';
+import env from 'Env';
 
 class Map extends Component {
   constructor(props) {

--- a/packages/react-components/src/dataManagement/api/ApiContext.js
+++ b/packages/react-components/src/dataManagement/api/ApiContext.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import ApiClient from './ApiClient';
-import env from '../../../.env.json';
+import env from 'Env';
 
 const client = new ApiClient({
   gql: {

--- a/packages/react-components/src/dataManagement/useTranslation.js
+++ b/packages/react-components/src/dataManagement/useTranslation.js
@@ -1,6 +1,6 @@
 import { useState, useEffect, useRef } from 'react';
 import axios from './api/axios';
-import env from '../../.env.json';
+import env from 'Env';
 import en from '../../locales/dist/en.json'; 
 
 const localeMappingPromise = axios.get(`${env.TRANSLATIONS}/translations.json`);

--- a/packages/react-components/src/entities/Collection/CollectionPresentation.js
+++ b/packages/react-components/src/entities/Collection/CollectionPresentation.js
@@ -24,7 +24,7 @@ import { OccurrenceCount, Homepage, FeatureList, Location, GenericFeature, GbifC
 import { DataHeader, HeaderWrapper, ContentWrapper, Headline, DeletedMessage, ErrorMessage, HeaderInfoWrapper, HeaderInfoMain, HeaderInfoEdit } from '../shared/header';
 import { PageError, Page404, PageLoader } from '../shared';
 
-import env from '../../../.env.json';
+import env from 'Env';
 const { TabList, RouterTab, Tab } = Tabs;
 
 export function CollectionPresentation({

--- a/packages/react-components/src/entities/EventSidebar/details/Map/Map.js
+++ b/packages/react-components/src/entities/EventSidebar/details/Map/Map.js
@@ -1,6 +1,6 @@
 import React, {useContext, useEffect, useRef, useState} from "react";
 import mapboxgl from 'mapbox-gl';
-import env from '../../../../../.env.json';
+import env from 'Env';
 import * as css from './map.styles';
 import ThemeContext from "../../../../style/themes/ThemeContext";
 

--- a/packages/react-components/src/entities/Institution/InstitutionPresentation.js
+++ b/packages/react-components/src/entities/Institution/InstitutionPresentation.js
@@ -11,7 +11,7 @@ import { Description as About } from './about/Description';
 import { Collections } from './collections/Collections';
 import { FormattedMessage } from 'react-intl';
 import { join } from '../../utils/util';
-import env from '../../../.env.json';
+import env from 'Env';
 import useBelow from '../../utils/useBelow';
 
 import { DataHeader, HeaderWrapper, ContentWrapper, Headline, DeletedMessage, ErrorMessage, HeaderInfoWrapper, HeaderInfoMain, HeaderInfoEdit } from '../shared/header';

--- a/packages/react-components/src/search/EventSearch/views/Download/DownloadPresentation.js
+++ b/packages/react-components/src/search/EventSearch/views/Download/DownloadPresentation.js
@@ -4,7 +4,7 @@ import SiteContext from '../../../../dataManagement/SiteContext'
 import { useDialogState } from "reakit/Dialog";
 import * as styles from './downloadPresentation.styles';
 import {Button, Popover, Progress, Skeleton} from '../../../../components';
-import env from '../../../../../.env.json';
+import env from 'Env';
 import {FilterContext} from "../../../../widgets/Filter/state";
 import {filter2predicate} from "../../../../dataManagement/filterAdapter";
 import {FormattedNumber} from "react-intl";

--- a/packages/react-components/src/search/EventSearch/views/Map/MapboxMap.js
+++ b/packages/react-components/src/search/EventSearch/views/Map/MapboxMap.js
@@ -1,7 +1,7 @@
 import React, { Component } from "react";
 import mapboxgl from 'mapbox-gl';
 import { getLayerConfig } from './getLayerConfig';
-import env from '../../../../../.env.json';
+import env from 'Env';
 
 class Map extends Component {
 

--- a/packages/react-components/src/search/EventSearch/views/Table/EventsTable.js
+++ b/packages/react-components/src/search/EventSearch/views/Table/EventsTable.js
@@ -8,7 +8,7 @@ import { ResultsHeader } from '../../../ResultsHeader';
 import { useDialogState } from "reakit/Dialog";
 import { useUpdateEffect } from "react-use";
 import { EventSidebar } from "../../../../entities/EventSidebar/EventSidebar";
-import env from '../../../../../.env.json';
+import env from 'Env';
 import { FilterContext } from "../../../../widgets/Filter/state";
 import {InlineFilterChip} from "../../../../widgets/Filter/utils/FilterChip";
 

--- a/packages/react-components/src/search/OccurrenceSearch/OccurrenceSearch.stories.js
+++ b/packages/react-components/src/search/OccurrenceSearch/OccurrenceSearch.stories.js
@@ -5,7 +5,7 @@ import { addDecorator } from '@storybook/react';
 import { MemoryRouter as Router, Route } from "react-router-dom";
 import AddressBar from '../../StorybookAddressBar';
 import { QueryParamProvider } from 'use-query-params';
-import env from '../../../.env.json';
+import env from 'Env';
 import OccurrenceSearch from './OccurrenceSearch';
 import Standalone from './Standalone';
 // const BACKBONE_KEY = 'd7dddbf4-2cf0-4f39-9b2a-bb099caae36c';

--- a/packages/react-components/src/search/OccurrenceSearch/views/Download/index.js
+++ b/packages/react-components/src/search/OccurrenceSearch/views/Download/index.js
@@ -9,7 +9,7 @@ import * as css from './styles';
 import ThemeContext from '../../../../style/themes/ThemeContext';
 import { MdFileDownload } from 'react-icons/md'
 import { Button, Message } from '../../../../components';
-import env from '../../../../../.env.json';
+import env from 'Env';
 
 const DOWNLOAD = `
 query($predicate: Predicate){

--- a/packages/react-components/src/search/OccurrenceSearch/views/Map/MapPresentation.js
+++ b/packages/react-components/src/search/OccurrenceSearch/views/Map/MapPresentation.js
@@ -20,7 +20,7 @@ import { ViewHeader } from '../ViewHeader';
 import MapComponentMB from './MapboxMap';
 import MapComponentOL from './OpenlayersMap';
 import * as css from './map.styles';
-import env from '../../../../../.env.json';
+import env from 'Env';
 import SiteContext from '../../../../dataManagement/SiteContext';
 import { FormattedMessage } from 'react-intl';
 import { getMapStyles } from './standardMapStyles';

--- a/packages/react-components/src/search/OccurrenceSearch/views/Map/MapboxMap.js
+++ b/packages/react-components/src/search/OccurrenceSearch/views/Map/MapboxMap.js
@@ -1,7 +1,7 @@
 import React, { Component } from "react";
 import mapboxgl from 'mapbox-gl';
 import { getLayerConfig } from './getLayerConfig';
-import env from '../../../../../.env.json';
+import env from 'Env';
 import klokantech from './openlayers/styles/klokantech.json';
 
 const mapStyles = {

--- a/packages/react-components/src/search/OccurrenceSearch/views/Map/openlayers/basemaps.js
+++ b/packages/react-components/src/search/OccurrenceSearch/views/Map/openlayers/basemaps.js
@@ -1,4 +1,4 @@
-import env from '../../../../../../.env.json';
+import env from 'Env';
 
 export const basemaps = {
   'EPSG_4326': {

--- a/packages/react-components/src/search/OccurrenceSearch/views/Map/openlayers/projections.js
+++ b/packages/react-components/src/search/OccurrenceSearch/views/Map/openlayers/projections.js
@@ -1,5 +1,5 @@
 import proj4 from 'proj4';
-import env from '../../../../../../.env.json';
+import env from 'Env';
 import queryString from 'query-string';
 import { basemaps } from './basemaps';
 import createBasicBaseMapStyle from './styles/basicBaseMap';

--- a/packages/react-components/src/search/OccurrenceSearch/views/Map/standardMapStyles.js
+++ b/packages/react-components/src/search/OccurrenceSearch/views/Map/standardMapStyles.js
@@ -1,4 +1,4 @@
-import env from '../../../../../.env.json';
+import env from 'Env';
 import MapComponentMB from './MapboxMap';
 import MapComponentOL from './OpenlayersMap';
 const pixelRatio = parseInt(window.devicePixelRatio) || 1;

--- a/packages/react-components/webpack.config.js
+++ b/packages/react-components/webpack.config.js
@@ -1,31 +1,48 @@
 const path = require('path');
+const fs = require("fs");
 
-module.exports = {
-  entry: './src/index.js',
-  output: {
-    path: path.resolve(__dirname, 'dist/lib'),
-    filename: 'gbif-react-components.js',
-    library: 'gbifReactComponents',
-    libraryTarget: 'var'
-  },
-  devtool: 'source-map',
-  externals: {
-    'react': 'React', // Case matters here 
-    'react-dom': 'ReactDOM', // Case matters here
-  },
-  module: {
-    rules: [
-      {
-        test: /\.(js|jsx)$/,
-        exclude: /node_modules/,
-        use: {
-          loader: "babel-loader",
-          options: {
-            plugins: ['transform-react-remove-prop-types', '@babel/plugin-transform-runtime'],
-            presets: ["@babel/preset-env", "@babel/preset-react", "@emotion/babel-preset-css-prop"]
+module.exports = (env, argv) => {
+  //Use .env.json if no mode is found in argv and env
+  const mode = argv.mode || env?.NODE_ENV || '';
+  let envFile = path.resolve(__dirname, `.env.${mode ? mode+".json" : "json"}`);
+  if (!fs.existsSync(envFile)) {
+    console.warn("Cannot find env file: "+ envFile );
+    envFile = path.resolve(__dirname, ".env.json");
+  }
+  console.log("Webpack is building with env: " + envFile);
+
+  return {
+    entry: './src/index.js',
+    output: {
+      path: path.resolve(__dirname, 'dist/lib'),
+      filename: 'gbif-react-components.js',
+      library: 'gbifReactComponents',
+      libraryTarget: 'var'
+    },
+    devtool: 'source-map',
+    externals: {
+      'react': 'React', // Case matters here
+      'react-dom': 'ReactDOM', // Case matters here
+    },
+    resolve: {
+      alias: {
+        'Env': envFile
+      }
+    },
+    module: {
+      rules: [
+        {
+          test: /\.(js|jsx)$/,
+          exclude: /node_modules/,
+          use: {
+            loader: "babel-loader",
+            options: {
+              plugins: ['transform-react-remove-prop-types', '@babel/plugin-transform-runtime'],
+              presets: ["@babel/preset-env", "@babel/preset-react", "@emotion/babel-preset-css-prop"]
+            }
           }
         }
-      }
-    ]
+      ]
+    }
   }
 };


### PR DESCRIPTION
Events App loads the configurations from .env.json, its file path is hardcoded. It would be more convenient if we is able to configure our application for multiple environments and allow the application to behave differently for each environment such as development, test, stage, production.

Main changes:

Create an Env alias linked to different .env.json,e,g: .env.production.json in storybook.js and main.js