### PR TITLE
Display error in sidebar due to missing fields

### DIFF
--- a/packages/react-components/src/entities/EventDatasetSidebar/EventDatasetSidebar.js
+++ b/packages/react-components/src/entities/EventDatasetSidebar/EventDatasetSidebar.js
@@ -102,7 +102,7 @@ export function EventDatasetSidebar({
                           return (
                             <span>
                               {contactName}
-                              {x.electronicMailAddress[0] && (
+                              {x.electronicMailAddress && x.electronicMailAddress[0] && (
                                 <>
                                   &nbsp;
                                   (<a href={`mailto:${x.electronicMailAddress[0]}`}>{x.electronicMailAddress[0]}</a>)

--- a/packages/react-components/src/entities/EventSidebar/EventSidebar.js
+++ b/packages/react-components/src/entities/EventSidebar/EventSidebar.js
@@ -6,7 +6,16 @@ import { useQuery } from '../../dataManagement/api';
 import { Intro } from './details/Intro';
 import { DistinctTaxa } from './taxa/DistinctTaxa';
 import { Header } from './Header';
-import { MdClose, MdInfo, MdImage } from "react-icons/md";
+import {
+  MdClose,
+  MdInfo,
+  MdImage,
+  MdWarning,
+  MdWarningAmber,
+  MdErrorOutline,
+  MdOutlineWifiTetheringErrorRounded, MdError, MdOutlineWarningAmber
+} from "react-icons/md";
+import {Group} from "./details/Groups";
 
 const { TabList, Tab, TapSeperator } = Tabs;
 const { TabPanel } = Tabs;
@@ -26,6 +35,10 @@ export function EventSidebar({
   const { data, error, loading, load } = useQuery(EVENT, { lazyLoad: true });
   const [activeId, setTab] = useState( 'details');
   const theme = useContext(ThemeContext);
+
+  function showError() {
+    setTab("error");
+  }
 
   useEffect(() => {
     if (typeof eventID !== 'undefined') {
@@ -54,10 +67,15 @@ export function EventSidebar({
           <Tab tabId="details" direction="left">
             <MdInfo />
           </Tab>
-          {data?.event?.distinctTaxa?.length > 0 && (
+          {data?.event?.distinctTaxa?.filter(Boolean).length > 0 && (
             <Tab tabId="distinctTaxa" direction="left">
               <MdImage />
             </Tab>
+          )}
+          {error && (
+              <Tab tabId="error" direction="left">
+                <MdOutlineWarningAmber color="red"  />
+              </Tab>
           )}
         </TabList>
       </Col>
@@ -67,7 +85,7 @@ export function EventSidebar({
         </Col>}
         {!isLoading &&
             <>
-              <Header data={data} error={error} />
+              <Header data={data} error={error} showError={showError}/>
               <TabPanel tabId='details'>
                 <Intro
                     data={data}
@@ -78,9 +96,22 @@ export function EventSidebar({
                     addEventTypeToSearch={addEventTypeToSearch}
                 />
               </TabPanel>
-              <TabPanel tabId='distinctTaxa'>
-                <DistinctTaxa data={data} loading={loading} error={error} />
-              </TabPanel>
+              {data?.event?.distinctTaxa?.filter(Boolean).length > 0 && (
+                  <TabPanel tabId='distinctTaxa'>
+                    < DistinctTaxa data={data} loading={loading} error={error} />
+                  </TabPanel>
+              )}
+              {error && (
+                  <TabPanel tabId='error'>
+                    {error && (
+                        <Group label="Errors" defaultOpen={true}>
+                          <div>
+                            <pre>{JSON.stringify(error,undefined,2)}</pre>
+                          </div>
+                        </Group>
+                    )}
+                  </TabPanel>
+              )}
             </>
         }
       </Col>

--- a/packages/react-components/src/entities/EventSidebar/Header.js
+++ b/packages/react-components/src/entities/EventSidebar/Header.js
@@ -1,22 +1,29 @@
 
 import { jsx } from '@emotion/react';
-import React, { useContext } from 'react';
+import React, {useContext, useState} from 'react';
 import { FormattedDate, FormattedMessage } from 'react-intl';
 import ThemeContext from '../../style/themes/ThemeContext';
 import * as css from './styles';
-import { Row, Col, IconFeatures, Eyebrow } from "../../components";
+import {Row, Col, IconFeatures, Eyebrow, Button} from "../../components";
 import useBelow from '../../utils/useBelow';
+import {MdOutlineWarningAmber} from "react-icons/md";
 
 export function Header({
   data,
   loading,
   error,
+  showError,
   className,
   ...props
 }) {
   const isBelow = useBelow(500);
   const theme = useContext(ThemeContext);
   const item = data?.event;
+
+  function toggleShowError() {
+    showError();
+  };
+
   return <Row wrap="no-wrap" css={css.header({ theme })} {...props}>
     <Col grow>
       <h1>{item.eventType?.concept ? item.eventType.concept : 'Event'}</h1>
@@ -34,6 +41,11 @@ export function Header({
                       locality={item.locality}
         />
       </div>
+      {error && (
+        <div><MdOutlineWarningAmber color="red" />
+          <Button appearance="link" onClick={showError}>&nbsp;  Warning: There are some issues related to this record!</Button>
+        </div>
+      )}
     </Col>
   </Row>
 };

--- a/packages/react-components/src/entities/EventSidebar/details/Groups.js
+++ b/packages/react-components/src/entities/EventSidebar/details/Groups.js
@@ -116,7 +116,7 @@ function Event({ showAll, termMap, event, setActiveEvent, addToSearch }) {
     alert(id);
   }
 
-  const isRootNode = !termMap.eventTypeHierarchy?.value || termMap.eventTypeHierarchy?.value.length < 2;
+  const isRootNode = !termMap?.eventTypeHierarchy?.value || termMap?.eventTypeHierarchy?.value.length < 2;
 
   return <Group label="eventDetails.groups.event">
     <Properties css={css.properties} breakpoint={800}>

--- a/packages/react-components/src/entities/EventSidebar/details/Intro.js
+++ b/packages/react-components/src/entities/EventSidebar/details/Intro.js
@@ -2,10 +2,11 @@ import React, { useContext, useState } from 'react';
 import ThemeContext from '../../../style/themes/ThemeContext';
 import { FormattedMessage } from 'react-intl';
 import * as css from '../styles';
-import { Row, Col, Switch } from "../../../components";
+import {Row, Col, Switch, Button} from "../../../components";
 import {Group, Groups} from './Groups';
 import {Summary} from "./Summary";
 import Map from "../../SiteSidebar/details/Map/Map";
+import {MdOutlineWarningAmber} from "react-icons/md";
 
 export function Intro({
   data = {},
@@ -22,7 +23,7 @@ export function Intro({
   const { event } = data;
   if (loading || !event) return <h2>Loading event information...</h2>;
 
-  const hasCoordinates = (event.decimalLatitude != null && event.decimalLongitude != null ) || event.wktConvexHull != null;
+  const hasCoordinates = (event?.decimalLatitude != null && event?.decimalLongitude != null ) || event?.wktConvexHull != null;
 
   return <Row direction="column" wrap="nowrap">
     <Col style={{ padding: '12px 0', paddingBottom: 50, overflow: 'auto' }} grow>
@@ -43,7 +44,6 @@ export function Intro({
         />
       </Group>
       }
-
       <Summary event={event} setActiveEvent={setActiveEvent} addEventTypeToSearch={addEventTypeToSearch} />
     </Col>
     <Col css={css.controlFooter({ theme })} grow={false}>

--- a/packages/react-components/src/entities/EventSidebar/details/Measurements.js
+++ b/packages/react-components/src/entities/EventSidebar/details/Measurements.js
@@ -10,7 +10,7 @@ export function Measurements({ data }) {
 
     let hasMeasurements = false;
     if (data?.documents?.results?.length > 0
-        && data.documents.results[0]?.measurementOrFacts?.length > 0) {
+        && data?.documents?.results[0]?.measurementOrFacts?.length > 0) {
         hasMeasurements = true;
     }
 
@@ -27,7 +27,7 @@ export function Measurements({ data }) {
     const hasField = (prop) => {
         return flattenResults.filter((mof) => Boolean(mof[`measurement${prop}`])).length > 0;
     };
-    
+
     const extraFields = ['Method', 'Remarks', 'DeterminedDate'].filter((field) => hasField(field));
     const getRows = () => {
         const rows = flattenResults.map(row => {

--- a/packages/react-components/src/entities/EventSidebar/details/Summaries.js
+++ b/packages/react-components/src/entities/EventSidebar/details/Summaries.js
@@ -11,14 +11,14 @@ const { Term: T, Value: V } = Properties;
 export function Summaries({ event, setActiveEvent, addToSearch, addEventTypeToSearch, data, showAll }) {
 
   let termMap = {}
-  Object.entries(data.results.facet).forEach(item => {
+  Object.entries(data?.results?.facet).forEach(item => {
     termMap[item[0]] = {
       "simpleName": item[0],
       "value": item[1]
     }
   })
 
-  Object.entries(data.results.occurrenceFacet).forEach(item => {
+  Object.entries(data?.results?.occurrenceFacet).forEach(item => {
     termMap[item[0]] = {
       "simpleName": item[0],
       "value": item[1]
@@ -26,8 +26,8 @@ export function Summaries({ event, setActiveEvent, addToSearch, addEventTypeToSe
   })
 
   let hasEventType = false;
-  if (data.results.documents.results?.length > 0
-      && data.results.documents.results[0]?.eventType?.concept) {
+  if (data?.results?.documents.results?.length > 0
+      && data?.results?.documents.results[0]?.eventType?.concept) {
     hasEventType = true;
   }
 
@@ -43,7 +43,7 @@ export function Summaries({ event, setActiveEvent, addToSearch, addEventTypeToSe
     rootNode = {
       key: eventHierarchy[0],
       name: eventTypeHierarchy[0],
-      isSelected: eventTypeHierarchy[0] == event.eventType.concept,
+      isSelected: eventTypeHierarchy[0] == event?.eventType?.concept,
       count: 1,
       isClickable: true,
       children: []
@@ -53,7 +53,7 @@ export function Summaries({ event, setActiveEvent, addToSearch, addEventTypeToSe
       const newNode = {
         key: eventHierarchy[i],
         name: eventTypeHierarchy[i],
-        isSelected: eventTypeHierarchy[i] == event.eventType.concept,
+        isSelected: eventTypeHierarchy[i] == event?.eventType?.concept,
         count: 1,
         isClickable: true,
         children: []
@@ -64,7 +64,7 @@ export function Summaries({ event, setActiveEvent, addToSearch, addEventTypeToSe
     }
 
     // add hierarchy from events
-    const eventHierarchyJoined = data?.results.facet.eventTypeHierarchyJoined.sort(function (a, b) {
+    const eventHierarchyJoined = data?.results?.facet?.eventTypeHierarchyJoined.sort(function (a, b) {
       return a.key.length - b.key.length
     });
     eventHierarchyJoined.forEach(hierarchy => {
@@ -93,12 +93,12 @@ export function Summaries({ event, setActiveEvent, addToSearch, addEventTypeToSe
     });
 
     // add hierarchy from mofs
-    const mofHierarchyJoined = data?.mofResults.facet.eventTypeHierarchyJoined.sort(function (a, b) {
+    const mofHierarchyJoined = data?.mofResults?.facet?.eventTypeHierarchyJoined.sort(function (a, b) {
       return a.key.length - b.key.length
     });
     //Calculate how may measurements attached to 'Survey','Sample','Find' etc
     const measurements = mofHierarchyJoined.reduce(function(measurementsCount, record){
-      let total = record.events?.facet?.measurementOrFactTypes.reduce(function(count, mft){
+      let total = record?.events?.facet?.measurementOrFactTypes.reduce(function(count, mft){
           count += mft.count;
           return count;
       }, 0)
@@ -135,7 +135,7 @@ export function Summaries({ event, setActiveEvent, addToSearch, addEventTypeToSe
     });
 
     // add hierarchy from occurrence
-    const occurrenceHierarchyJoined = data?.results.occurrenceFacet.eventTypeHierarchyJoined.sort(function (a, b) {
+    const occurrenceHierarchyJoined = data?.results?.occurrenceFacet?.eventTypeHierarchyJoined.sort(function (a, b) {
       return a.key.length - b.key.length
     });
     occurrenceHierarchyJoined.forEach(hierarchy => {
@@ -148,7 +148,7 @@ export function Summaries({ event, setActiveEvent, addToSearch, addEventTypeToSe
         // do we have this child node already ?
         let existingChild = startingNode.children.find(node => node.key == nodes[i]);
         if (!existingChild){
-          let count = data.results.occurrenceFacet?.datasetKey[0]?.count ?? 0;
+          let count = data.results?.occurrenceFacet?.datasetKey[0]?.count ?? 0;
           let newNode = {
             key: nodes[i],
             name: nodes[i],

--- a/packages/react-components/src/entities/EventSidebar/taxa/DistinctTaxa.js
+++ b/packages/react-components/src/entities/EventSidebar/taxa/DistinctTaxa.js
@@ -54,7 +54,8 @@ export function DistinctTaxa({
           style={{ padding: '12px', paddingBottom: '48px', overflow: 'auto' }}
           grow
         >
-          {event.distinctTaxa.map((taxon) => (
+          {
+            event.distinctTaxa?.filter(Boolean).map((taxon) => (
             <div
               key={taxon.key}
               style={{

--- a/packages/react-components/src/entities/SiteSidebar/details/Summaries.js
+++ b/packages/react-components/src/entities/SiteSidebar/details/Summaries.js
@@ -8,14 +8,14 @@ const { Term: T, Value: V } = Properties;
 
 export function Summaries({ data, showAll }) {
   let termMap = {}
-  Object.entries(data.results.facet).forEach(item => {
+  Object.entries(data?.results?.facet).forEach(item => {
     termMap[item[0]] = {
       "simpleName": item[0],
       "value": item[1]
     }
   })
 
-  Object.entries(data.results.occurrenceFacet).forEach(item => {
+  Object.entries(data?.results?.occurrenceFacet).forEach(item => {
     termMap[item[0]] = {
       "simpleName": item[0],
       "value": item[1]
@@ -42,13 +42,13 @@ function TaxonomicCoverage({ showAll, termMap }) {
 
   return <Group label="eventDetails.groups.taxonomicCoverage">
     <Properties css={css.properties} breakpoint={800}>
-      <FacetListInline term={termMap.kingdom} showDetails={showAll}/>
-      <FacetListInline term={termMap.phylum} showDetails={showAll}/>
-      <FacetListInline term={termMap.class} showDetails={showAll}/>
-      <FacetListInline term={termMap.order} showDetails={showAll}/>
-      <FacetListInline term={termMap.family} showDetails={showAll}/>
-      <FacetListInline term={termMap.genus} showDetails={showAll} style={{ fontStyle: "italic" }}/>
-      <FacetListInline term={termMap.species} showDetails={showAll} style={{ fontStyle: "italic" }}/>
+      <FacetListInline term={termMap?.kingdom} showDetails={showAll}/>
+      <FacetListInline term={termMap?.phylum} showDetails={showAll}/>
+      <FacetListInline term={termMap?.class} showDetails={showAll}/>
+      <FacetListInline term={termMap?.order} showDetails={showAll}/>
+      <FacetListInline term={termMap?.family} showDetails={showAll}/>
+      <FacetListInline term={termMap?.genus} showDetails={showAll} style={{ fontStyle: "italic" }}/>
+      <FacetListInline term={termMap?.species} showDetails={showAll} style={{ fontStyle: "italic" }}/>
     </Properties>
   </Group>
 }
@@ -66,9 +66,9 @@ function Methodology({ showAll, termMap }) {
   if (!hasContent) return null;
   return <Group label="eventDetails.groups.methodology">
     <Properties css={css.properties} breakpoint={800}>
-      <FacetList term={termMap.samplingProtocol} showDetails={showAll} />
-      <FacetList term={termMap.recordedBy} showDetails={showAll} />
-      <FacetList term={termMap.measurementOrFactTypes} showDetails={showAll} />
+      <FacetList term={termMap?.samplingProtocol} showDetails={showAll} />
+      <FacetList term={termMap?.recordedBy} showDetails={showAll} />
+      <FacetList term={termMap?.measurementOrFactTypes} showDetails={showAll} />
     </Properties>
   </Group>
 }

--- a/packages/react-components/src/search/EventSearch/views/Sites/SitesTable.js
+++ b/packages/react-components/src/search/EventSearch/views/Sites/SitesTable.js
@@ -181,7 +181,7 @@ export const SitesDataGrid = ({ siteMatrix, siteData, years, setSiteIDCallback, 
                 </li>
             )
           }
-        </ul>  
+        </ul>
       )
     )
   }


### PR DESCRIPTION
Relate to : https://github.com/AtlasOfLivingAustralia/extended-data-model/issues/99

The sidebar displays error when some records miss fields
- Add more null checks on fields
- Add error panel in sidebar for displaying error message returned from GraphQL
=