### PR TITLE
ALA taxonMedia resolver tweaks

### DIFF
--- a/packages/graphql-api/src/resources/ala/taxonMedia/taxonMedia.source.js
+++ b/packages/graphql-api/src/resources/ala/taxonMedia/taxonMedia.source.js
@@ -40,9 +40,7 @@ class TaxonMediaAPI extends RESTDataSource {
     // Append filter queries
     [
       '-typeStatus:*',
-      '-basisOfRecord:PreservedSpecimen',
       '-identificationQualifier:"Uncertain"',
-      'spatiallyValid:true',
       '-userAssertions:50001',
       '-userAssertions:50005',
       ...Object.entries(params?.filter || {}).map(

--- a/packages/graphql-api/src/resources/ala/taxonMedia/taxonMedia.source.js
+++ b/packages/graphql-api/src/resources/ala/taxonMedia/taxonMedia.source.js
@@ -74,6 +74,8 @@ class TaxonMediaAPI extends RESTDataSource {
           scientificName,
           speciesGroups,
           occurrenceDetails,
+          dataResourceUid,
+          dataResourceName,
           imageMetadata,
         }) => {
           return {
@@ -91,7 +93,8 @@ class TaxonMediaAPI extends RESTDataSource {
               imageMetadata.license?.includes('http') && imageMetadata.license,
             credit: imageMetadata.rights,
             creator: imageMetadata.creator,
-            // providerLiteral: null,
+            provider: dataResourceUid,
+            providerLiteral: dataResourceName,
             description: imageMetadata.description || occurrenceDetails,
             tag: speciesGroups.join(', '),
             createDate: imageMetadata.created,

--- a/packages/graphql-api/src/resources/shared/resources/taxonMedia/taxonMedia.type.js
+++ b/packages/graphql-api/src/resources/shared/resources/taxonMedia/taxonMedia.type.js
@@ -19,6 +19,7 @@ const typeDef = gql`
     webStatement: String
     credit: String
     creator: String
+    provider: String
     providerLiteral: String
     description: String
     tag: String


### PR DESCRIPTION
The PR contains small changes/tweaks to improve the ALA `taxonMedia` resolver

Changes include:
- Removed the default `basisOfRecord` and `spatiallyValid` filter query parameters of the ALA `taxonMedia` source
- The addition of a new provider field to the `Image` type
  - Used to provide the `dataResourceUid` field for ALA
- The `providerLiteral` property now returns the `dataResourceName` field for ALA