### PR TITLE
Feat 330 routing refactor

### DIFF
--- a/packages/react-components/.storybook/preview.js
+++ b/packages/react-components/.storybook/preview.js
@@ -99,7 +99,7 @@ addDecorator(storyFn => {
                     'ltr',
                   ),
                 )}>
-                  <RouteContext.Provider value={siteConfig.routeConfig}>
+                  <RouteContext.Provider value={siteConfig.routes}>
                     {storyFn()}
                   </RouteContext.Provider>
                   <div style={{zIndex: 10000, position: 'fixed'}}>

--- a/packages/react-components/.storybook/siteConfig.js
+++ b/packages/react-components/.storybook/siteConfig.js
@@ -1,6 +1,8 @@
 import env from '../.env.json';
+const gbifOrg = 'https://www.gbif.org';
 
 const routeConfig = {
+  enabledRoutes: ['datasetSearch', 'occurrenceSearch', 'institutionKey', 'institutionSearch', 'publisherSearch', 'collectionSearch', 'collectionKey', 'datasetKey'],
   occurrenceSearch: {
     url: ({ queryString }) => {
       return `/iframe.html?args=&id=search-occurrencesearch--standalone-example&viewMode=story${queryString}`;
@@ -10,12 +12,18 @@ const routeConfig = {
     route: '/occurrence/search',
   },
 
+  speciesSearch: {
+    url: ({ queryString }) => `${gbifOrg}/species/search?${queryString}`,
+    isHref: true,
+    route: '/species/search',
+  },
+
   collectionKey: {
     isHref: true,
     url: ({ key }) => {
       return `/?path=/story/entities-collection-page--example&knob-collectionUUID=${key}`;
     },
-    route: '/',
+    route: '/'
   },
   collectionSearch: {
     // url: () => `/collection/`,
@@ -26,13 +34,15 @@ const routeConfig = {
     route: '/collection/search',
   },
   collectionKeySpecimens: {
+    parent: 'collectionKey',
     // url: ({ key }) => `/collection/${key}/specimens`
-    url: ({route, queryString, basename, key}) => `${basename ? `/${basename}` : ''}/collection/${key}/specimens${queryString ? `?${queryString}` : ''}`,
+    url: ({ route, queryString, basename, key }) => `${basename ? `/${basename}` : ''}/collection/${key}/specimens${queryString ? `?${queryString}` : ''}`,
     route: '/specimens',
   },
   collectionKeyDashboard: {
+    parent: 'collectionKey',
     // url: ({ key }) => `/collection/${key}/specimens`
-    url: ({route, queryString, basename, key}) => `${basename ? `/${basename}` : ''}/collection/${key}/specimens${queryString ? `?${queryString}` : ''}`,
+    url: ({ route, queryString, basename, key }) => `${basename ? `/${basename}` : ''}/collection/${key}/specimens${queryString ? `?${queryString}` : ''}`,
     route: '/dashboard',
   },
 
@@ -40,14 +50,15 @@ const routeConfig = {
     isHref: true,
     url: ({ key }) => {
       return `/?path=/story/entities-institution-page--example&knob-institutionUUID=${key}`;
-    }
+    },
+    route: '/institution/:key',
   },
   institutionKeySpecimens: {
-    url: ({key}) => `/specimens`,
+    url: ({ key }) => `/specimens`,
     isHref: false,
   },
   institutionKeyCollections: {
-    url: ({key}) => `/collections`,
+    url: ({ key }) => `/collections`,
     isHref: false,
   },
   institutionSearch: {
@@ -67,6 +78,14 @@ const routeConfig = {
       return `/?path=/story/entities-dataset-page--example&knob-Choose%20Direction=ltr&knob-Choose%20locale=en-DK&knob-datasetUUID=${key}`;
     },
     route: '/'
+  },
+  datasetCitations: {
+    route: '/dataset/:key/citations',
+    url: ({ key }) => `/dataset/${key}/citations`
+  },
+  datasetDownload: {
+    route: '/dataset/:key/download',
+    url: ({ key }) => `/dataset/${key}/download`
   },
   datasetSearch: {
     // url: () => `/dataset-search/`,
@@ -106,12 +125,12 @@ const routeConfig = {
   eventKey: {
     // url: ({key}) => `/publisher/${key}`,
     // url: ({key, otherIds}) => `${gbifOrg}/dataset/${otherIds.datasetKey}/event/${key}`,
-    url: ({key, otherIds}) => `https://collections.ala.org.au/public/showDataResource/${otherIds.datasetKey}?event=${key}`,
+    url: ({ key, otherIds }) => `https://collections.ala.org.au/public/showDataResource/${otherIds.datasetKey}?event=${key}`,
     isHref: true,
     route: '/event/:key'
   },
   eventSearch: {
-    url: ({queryString, basename}) => `${basename ? `/${basename}` : ''}/event/search`,
+    url: ({ queryString, basename }) => `${basename ? `/${basename}` : ''}/event/search`,
     isHref: true,
     route: '/publisher/search'
   },
@@ -122,13 +141,13 @@ const routeConfig = {
   },
   networkKey: {
     isHref: true,
-    url: ({key}) => `${env.GBIF_ORG}/network/${key}`,
+    url: ({ key }) => `${env.GBIF_ORG}/network/${key}`,
     route: '/'
   },
 };
 
 export const siteConfig = {
-  routeConfig,
+  routes: routeConfig,
   occurrence: {
     mapSettings: {
       userLocationEnabled: true,
@@ -155,7 +174,7 @@ export const siteConfig = {
     bing: 'need to make a call to register',
     maptiler: env._FOR_STORYBOOK_BUT_PUBLIC?.apiKeys?.maptiler
   },
-  availableCatalogues: ['OCCURRENCE', 'DATASET', 'PUBLISHER', 'LITERATURE', 'COLLECTION', 'INSTITUTION'],
+  // availableCatalogues: ['OCCURRENCE', 'DATASET', 'PUBLISHER', 'LITERATURE', 'COLLECTION', 'INSTITUTION'],
   maps: {
     // locale: 'ja',
     defaultProjection: 'MERCATOR',

--- a/packages/react-components/src/App.js
+++ b/packages/react-components/src/App.js
@@ -1,0 +1,91 @@
+import React, { useContext } from "react";
+import StandaloneWrapper from './StandaloneWrapper';
+
+import { Collection } from './entities/Collection/Collection';
+import CollectionSearch from './search/CollectionSearch/CollectionSearch';
+import { Institution } from './entities/Institution/Institution';
+import InstitutionSearch from './search/InstitutionSearch/InstitutionSearch';
+
+import { Dataset } from './entities/Dataset/Dataset';
+import DatasetSearch from './search/DatasetSearch/DatasetSearch';
+import PublisherSearch from './search/PublisherSearch/PublisherSearch';
+import LiteratureSearch from './search/LiteratureSearch/LiteratureSearch';
+import OccurrenceSearch from './search/OccurrenceSearch/OccurrenceSearch';
+
+import { Switch, Route, Link } from 'react-router-dom';
+import RouteContext from './dataManagement/RouteContext';
+
+function Wrap({ siteConfig, router, ...props }) {
+  return <StandaloneWrapper siteConfig={siteConfig} router={router}>
+    <Standalone {...props} siteConfig={siteConfig} />
+  </StandaloneWrapper>
+}
+
+function Standalone(props) {
+  const routeContext = useContext(RouteContext); 
+  return <Switch>
+    <Route
+      exact
+      path={routeContext.collectionSearch.route}
+      render={routeProps => <CollectionSearch pageLayout config={props?.siteConfig?.collection} {...props} {...routeProps} />}
+    />
+    <Route
+      path={routeContext.collectionKey.route}
+      render={routeProps => <Collection id={routeProps.match.params.key} {...props} {...routeProps} />}
+    />
+    <Route
+      exact
+      path={routeContext.institutionSearch.route}
+      render={routeProps => <InstitutionSearch pageLayout config={props?.siteConfig?.institution} {...props} {...routeProps} />}
+    />
+    <Route
+      path={routeContext.institutionKey.route}
+      render={routeProps => <Institution id={routeProps.match.params.key} {...props} {...routeProps} />}
+    />
+    <Route
+      exact
+      path={routeContext.datasetSearch.route}
+      render={routeProps => <DatasetSearch pageLayout config={props?.siteConfig?.dataset} {...props} {...routeProps} />}
+    />
+    <Route
+      path={routeContext.datasetKey.route}
+      render={routeProps => <Dataset id={routeProps.match.params.key} {...props} {...routeProps} />}
+    />
+    <Route
+      exact
+      path={routeContext.publisherSearch.route}
+      render={routeProps => <PublisherSearch pageLayout config={props?.siteConfig?.publisher} {...props} {...routeProps} />}
+    />
+    <Route
+      exact
+      path={routeContext.literatureSearch.route}
+      render={routeProps => <LiteratureSearch pageLayout config={props?.siteConfig?.literature} {...props} {...routeProps} />}
+    />
+    <Route
+      exact
+      path={routeContext.occurrenceSearch.route}
+      render={routeProps => <OccurrenceSearch pageLayout config={props?.siteConfig?.occurrence} {...props} {...routeProps} />}
+    />
+    <Route
+      path='/'
+      render={routeProps => <div>
+        <h1>Select a route to start</h1>
+        <ul>
+          <li><Link to={routeContext.collectionSearch.route}>Collection search</Link></li>
+          <li><Link to="/collection/dceb8d52-094c-4c2c-8960-75e0097c6861">Collection example</Link></li>
+          <li><Link to={routeContext.institutionSearch.route}>Institution search</Link></li>
+          <li><Link to="/institution/fa252605-26f6-426c-9892-94d071c2c77f">Institution example</Link></li>
+          <li><Link to={routeContext.datasetSearch.route}>Dataset search</Link></li>
+          <li><Link to="/dataset/2985efd1-45b1-46de-b6db-0465d2834a5a">Dataset example</Link></li>
+          <li><Link to={routeContext.publisherSearch.route}>Publisher search</Link></li>
+          <li><Link to={routeContext.literatureSearch.route}>Literature search</Link></li>
+          <li><Link to={routeContext.occurrenceSearch.route}>Occurrence search</Link></li>
+        </ul>
+      </div>}
+    />
+  </Switch>
+}
+
+
+
+export default Wrap;

--- a/packages/react-components/src/App.stories.js
+++ b/packages/react-components/src/App.stories.js
@@ -1,0 +1,11 @@
+import React from 'react';
+import { MemoryRouter as Router } from "react-router-dom";
+import App from './App';
+import { defaultContext as defaultSiteConfig } from './dataManagement/SiteContext';
+
+export const StandaloneExample = () => <App siteConfig={defaultSiteConfig} router={Router} />;
+
+export default {
+  title: 'App/Hosted portal',
+  component: StandaloneExample,
+};

--- a/packages/react-components/src/components/resourceLinks/resourceLinks.js
+++ b/packages/react-components/src/components/resourceLinks/resourceLinks.js
@@ -4,24 +4,7 @@ import RouteContext from '../../dataManagement/RouteContext';
 import LocaleContext from '../../dataManagement/LocaleProvider/LocaleContext';
 import { Link, useHistory } from "react-router-dom";
 
-export const ResourceSearchLink = React.forwardRef(({ queryString, type, discreet, ...props }, ref) => {
-  const routeContext = useContext(RouteContext);
-  const basename = routeContext.basename;
-  if (!routeContext[type]) {
-    console.warn(`No such route: ${type}`)
-    return null;
-  }
-  const { url, isHref, route } = routeContext[type];
-  const to = url({ queryString, basename, route });
-  const style = discreet ? isDiscreet : null;
-  if (isHref) {
-    return <a href={to} css={style} ref={ref} {...props} />
-  } else {
-    return <Link to={to} css={style} ref={ref} {...props} />
-  }
-});
-
-export const ResourceLink = React.forwardRef(({ id, type, otherIds, discreet, bold, localeContext: localeOverwrite, routeContext: routeOverwrite, ...props }, ref) => {
+export const ResourceLink = React.forwardRef(({ id, type, queryString, otherIds, discreet, bold, localeContext: localeOverwrite, routeContext: routeOverwrite, ...props }, ref) => {
   const localeSettings = useContext(LocaleContext);
   const routeSettings = useContext(RouteContext);
 
@@ -29,22 +12,40 @@ export const ResourceLink = React.forwardRef(({ id, type, otherIds, discreet, bo
   const routeContext = routeOverwrite || routeSettings;
 
   const basename = routeContext.basename;
+  if (!routeContext[type]) {
+    console.warn(`No such route: ${type}`)
+    return null;
+  }
+
   const gbifOrgLocale = localeContext?.localeMap?.gbif_org;
-  const { url, isHref, route } = routeContext[type];
-  const to = url({ key: id, otherIds, route, basename, gbifOrgLocalePrefix: gbifOrgLocale ? `/${gbifOrgLocale}` : '' });
+  const { alwaysUseHrefs = false, enabledRoutes = [] } = routeContext;
+  const { url, isHref, route, gbifUrl, parent } = routeContext[type];
+
+  // check to see if the route is enabled or we should use GBIF routes
+  const types = [type];
+  if (parent) types.push(parent);
+  const intersection = enabledRoutes.filter(value => types.includes(value));
+  const useGBIF = intersection.length === 0;
+
+  const urlBuilder = useGBIF ? (gbifUrl ?? url) : (url ?? gbifUrl);
+
+  const to = urlBuilder({ key: id, otherIds, queryString, route, basename, gbifOrgLocalePrefix: gbifOrgLocale ? `/${gbifOrgLocale}` : '' });
   let style = isDiscreetLink;
   if (discreet) style = isDiscreet;
   if (bold) style = isBoldLink;
-  if (isHref) {
-    return <a href={to} css={style} {...props} />
+  if (useGBIF || alwaysUseHrefs || isHref) {
+    return <a href={to} css={style} ref={ref} {...props} />
   } else {
-    return <Link to={to} css={style} {...props} />
+    return <Link to={to} css={style} ref={ref} {...props} />
   }
 });
+
+export const ResourceSearchLink = ResourceLink;
 
 export const resourceAction =  ({ id: key, type, history, localeSettings, routeContext, ...rest }) => {
   const basename = routeContext.basename;
   const gbifOrgLocale = localeSettings?.localeMap?.gbif_org;
+  const { alwaysUseHrefs = false } = routeContext;
   const { url, isHref, route } = routeContext[type];
   const gbifOrgLocalePrefix = gbifOrgLocale ? `/${gbifOrgLocale}` : '';
   const to = url({
@@ -56,7 +57,7 @@ export const resourceAction =  ({ id: key, type, history, localeSettings, routeC
     isHref,
     ...rest
   });
-  if (isHref) {
+  if (alwaysUseHrefs || isHref) {
     location.href = to;
   } else {
     history.push(to);

--- a/packages/react-components/src/dataManagement/RouteContext.js
+++ b/packages/react-components/src/dataManagement/RouteContext.js
@@ -1,83 +1,98 @@
 import React from 'react';
 const gbifOrg = 'https://www.gbif.org';
 
+// no matter if it is a plain a-tag link or a react-router link, we need to know how to contruct the url
+// and we need to know how to construct the route
+// and finally we need to know if it is a react-router link or not
 export const defaultContext = {
+  alwaysUseHrefs: false,
+  // enabledRoutes: ['datasetSearch', 'occurrenceSearch', 'institutionKey', 'institutionSearch', 'publisherSearch', 'collectionSearch', 'collectionKey', 'datasetKey'],
   occurrenceSearch: {
     url: ({route, queryString, basename}) => `${basename ? `/${basename}` : ''}${route}${queryString ? `?${queryString}` : ''}`,
+    gbifUrl: ({route, queryString, gbifOrgLocalePrefix}) => `${gbifOrg}${gbifOrgLocalePrefix}/occurrence/search${queryString ? `?${queryString}` : ''}`,
     route: '/occurrence/search',
-    isHref: true,
+    isHref: false,
   },
   collectionKey: {
-    // url: ({key}) => `/collection/${key}`,
-    url: ({key}) => `${gbifOrg}/grscicoll/collection/${key}`,
-    isHref: true,
+    url: ({key}) => `/collection/${key}`,
+    gbifUrl: ({key, gbifOrgLocalePrefix}) => `${gbifOrg}${gbifOrgLocalePrefix}/grscicoll/collection/${key}`,
+    isHref: false,
     route: '/collection/:key'
   },
   collectionSearch: {
     url: ({queryString, basename}) => `${basename ? `/${basename}` : ''}/collection/search`,
-    isHref: true,
+    gbifUrl: ({route, queryString, gbifOrgLocalePrefix}) => `${gbifOrg}${gbifOrgLocalePrefix}/grscicoll/collection/search${queryString ? `?${queryString}` : ''}`,
+    isHref: false,
     route: '/collection/search'
   },
   collectionKeySpecimens: {
+    parent: 'collectionKey',
     url: ({key}) => `/collection/${key}/specimens`,
+    gbifUrl: ({key, gbifOrgLocalePrefix}) => `${gbifOrg}${gbifOrgLocalePrefix}/grscicoll/collection/${key}`,
     isHref: false,
     route: '/collection/:key/specimens'
   },
   collectionKeyDashboard: {
     url: ({key}) => `/collection/${key}/specimens`,
+    gbifUrl: ({key, gbifOrgLocalePrefix}) => `${gbifOrg}${gbifOrgLocalePrefix}/grscicoll/collection/${key}/metrics`,
     isHref: false,
     route: '/collection/:key/dashboard'
   },
 
   institutionKey: {
-    // url: ({key}) => `/institution/${key}`,
-    url: ({key}) => `${gbifOrg}/grscicoll/institution/${key}`,
-    isHref: true,
+    url: ({key}) => `/institution/${key}`,
+    gbifUrl: ({key, gbifOrgLocalePrefix}) => `${gbifOrg}${gbifOrgLocalePrefix}/grscicoll/institution/${key}`,
+    isHref: false,
     route: '/institution/:key'
   },
   institutionKeySpecimens: {
-    url: ({key}) => `${gbifOrg}/grscicoll/institution/${key}`,
+    url: ({key}) => `${gbifOrg}${gbifOrgLocalePrefix}/grscicoll/institution/${key}`,
+    gbifUrl: ({key, gbifOrgLocalePrefix}) => `${gbifOrg}${gbifOrgLocalePrefix}/grscicoll/institution/${key}`,
     isHref: false,
     route: '/institution/:key/specimens'
   },
   institutionKeyCollections: {
     url: ({key}) => `/collections`,
+    gbifUrl: ({key, gbifOrgLocalePrefix}) => `${gbifOrg}${gbifOrgLocalePrefix}/grscicoll/institution/${key}`,
     isHref: false,
     route: '/institution/:key/collections'
   },
   institutionSearch: {
     url: ({queryString, basename}) => `${basename ? `/${basename}` : ''}/institution/search`,
-    isHref: true,
+    gbifUrl: ({route, queryString, gbifOrgLocalePrefix}) => `${gbifOrg}${gbifOrgLocalePrefix}/grscicoll/institution/search${queryString ? `?${queryString}` : ''}`,
+    isHref: false,
     route: '/institution/search'
   },
 
   datasetKey: {
-    // url: ({key}) => `/dataset/${key}`,
-    url: ({key, gbifOrgLocalePrefix}) => `${gbifOrg}${gbifOrgLocalePrefix}/dataset/${key}`,
-    isHref: true,
+    url: ({key}) => `/dataset/${key}`,
+    gbifUrl: ({key, gbifOrgLocalePrefix}) => `${gbifOrg}${gbifOrgLocalePrefix}/dataset/${key}`,
+    isHref: false,
     route: '/dataset/:key'
   },
   datasetSearch: {
     url: ({queryString, basename}) => `${basename ? `/${basename}` : ''}/dataset/search`,
-    isHref: true,
+    gbifUrl: ({route, queryString, gbifOrgLocalePrefix}) => `${gbifOrg}${gbifOrgLocalePrefix}/dataset/search${queryString ? `?${queryString}` : ''}`,
+    isHref: false,
     route: '/dataset/search'
   },
 
   publisherKey: {
-    // url: ({key}) => `/publisher/${key}`,
-    url: ({key}) => `${gbifOrg}/publisher/${key}`,
+    gbifUrl: ({key, gbifOrgLocalePrefix}) => `${gbifOrg}${gbifOrgLocalePrefix}/publisher/${key}`,
     isHref: true,
     route: '/publisher/:key'
   },
   publisherSearch: {
     url: ({queryString, basename}) => `${basename ? `/${basename}` : ''}/publisher/search`,
-    isHref: true,
+    gbifUrl: ({route, queryString, gbifOrgLocalePrefix}) => `${gbifOrg}${gbifOrgLocalePrefix}/publisher/search${queryString ? `?${queryString}` : ''}`,
+    isHref: false,
     route: '/publisher/search'
   },
 
   literatureSearch: {
     url: ({queryString, basename}) => `${basename ? `/${basename}` : ''}/literature/search`,
-    isHref: true,
+    gbifUrl: ({route, queryString, gbifOrgLocalePrefix}) => `${gbifOrg}${gbifOrgLocalePrefix}/resource/search?contentType=literature&${queryString ? `${queryString}` : ''}`,
+    isHref: false,
     route: '/literature/search'
   },
 

--- a/packages/react-components/src/dataManagement/SiteContext.js
+++ b/packages/react-components/src/dataManagement/SiteContext.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { defaultContext as defaultRouteConfig } from './RouteContext';
 
 export const defaultContext = {
-  routeConfig: defaultRouteConfig,
+  routes: defaultRouteConfig,
   occurrence: {},
   dataset: {},
   literature: {},
@@ -10,6 +10,7 @@ export const defaultContext = {
   collection: {},
   publisher: {},
   apiKeys: {},
+  availableCatalogues: ['OCCURRENCE', 'DATASET', 'PUBLISHER', 'LITERATURE', 'COLLECTION', 'INSTITUTION'],
   maps: {
     defaultProjection: 'MERCATOR',
     defaultMapStyle: 'NATURAL',

--- a/packages/react-components/src/entities/Collection/Collection.stories.js
+++ b/packages/react-components/src/entities/Collection/Collection.stories.js
@@ -1,17 +1,18 @@
-import React from 'react';
+import React, { useContext } from 'react';
 import { text } from '@storybook/addon-knobs';
 import { Collection } from './Collection';
 import { MemoryRouter as Router, Route } from "react-router-dom";
 import AddressBar from '../../StorybookAddressBar';
 import Standalone from './Standalone';
 import { QueryParamProvider } from 'use-query-params';
+import { siteConfig } from '../../../.storybook/siteConfig';
 
 export default {
   title: 'Entities/Collection page',
   component: Collection,
 };
 
-export const Example = () => <Router initialEntries={[`/dashboard`]}>
+export const Example = () => <Router initialEntries={[`/`]}>
   <QueryParamProvider ReactRouterRoute={Route}>
     <AddressBar />
     <div style={{ flex: '1 1 auto' }}></div>
@@ -40,4 +41,6 @@ Example.story = {
   name: 'Collection page',
 };
 
-export const StandaloneExample = () => <Standalone id="dceb8d52-094c-4c2c-8960-75e0097c6861"></Standalone>;
+export const StandaloneExample = () => {
+  return <Standalone id="dceb8d52-094c-4c2c-8960-75e0097c6861" siteConfig={siteConfig}></Standalone>
+}

--- a/packages/react-components/src/entities/Collection/Standalone.js
+++ b/packages/react-components/src/entities/Collection/Standalone.js
@@ -4,17 +4,26 @@ import { Collection } from './Collection';
 import { Switch, Route } from 'react-router-dom';
 import RouteContext from '../../dataManagement/RouteContext';
 
-function Standalone(props) {
-  const routeContext = useContext(RouteContext);
-  const path = routeContext.collectionKey.route;
-  return <StandaloneWrapper {...props}>
-    <Switch>
-      <Route
-        path={path}
-        render={routeProps => <Collection id={routeProps.match.params.key} {...props} {...routeProps}/>}
-      />
-    </Switch>
+function Wrap({ siteConfig, ...props }) {
+  if (siteConfig?.routes) siteConfig.routes.alwaysUseHrefs = true;
+  return <StandaloneWrapper siteConfig={siteConfig}>
+    <Standalone {...props} />
   </StandaloneWrapper>
 }
 
-export default Standalone;
+function Standalone(props) {
+  const routeContext = useContext(RouteContext);
+  // if an explitit id is passed in, use it instead of extracting it from the route
+  if (props.id) {
+    return <Collection {...props} />
+  }
+  const path = routeContext.collectionKey.route;
+  return <Switch>
+    <Route
+      path={path}
+      render={routeProps => <Collection id={routeProps.match.params.key} {...props} {...routeProps}/>}
+    />
+  </Switch>
+}
+
+export default Wrap;

--- a/packages/react-components/src/entities/Dataset/Standalone.js
+++ b/packages/react-components/src/entities/Dataset/Standalone.js
@@ -5,6 +5,7 @@ import { Switch, Route } from 'react-router-dom';
 import RouteContext from '../../dataManagement/RouteContext';
 
 function Wrap({ siteConfig, ...props }) {
+  if (siteConfig?.routes) siteConfig.routes.alwaysUseHrefs = true;
   return <StandaloneWrapper siteConfig={siteConfig}>
     <Standalone {...props} />
   </StandaloneWrapper>
@@ -12,6 +13,10 @@ function Wrap({ siteConfig, ...props }) {
 
 function Standalone(props) {
   const routeContext = useContext(RouteContext);
+  // if an explitit id is passed in, use it instead of extracting it from the route
+  if (props.id) {
+    return <Dataset {...props} />
+  }
   const path = routeContext.datasetKey.route;
   return <Switch>
     <Route

--- a/packages/react-components/src/entities/Institution/Standalone.js
+++ b/packages/react-components/src/entities/Institution/Standalone.js
@@ -4,8 +4,19 @@ import { Institution } from './Institution';
 import { Switch, Route } from 'react-router-dom';
 import RouteContext from '../../dataManagement/RouteContext';
 
+function Wrap({ siteConfig, ...props }) {
+  if (siteConfig?.routes) siteConfig.routes.alwaysUseHrefs = true;
+  return <StandaloneWrapper siteConfig={siteConfig}>
+    <Standalone {...props} />
+  </StandaloneWrapper>
+}
+
 function Standalone(props) {
   const routeContext = useContext(RouteContext);
+  // if an explitit id is passed in, use it instead of extracting it from the route
+  if (props.id) {
+    return <Institution {...props} />
+  }
   const path = routeContext.institutionKey.route;
   return <StandaloneWrapper {...props}>
     <Switch>
@@ -17,4 +28,4 @@ function Standalone(props) {
   </StandaloneWrapper>
 }
 
-export default Standalone;
+export default Wrap;

--- a/packages/react-components/src/index.js
+++ b/packages/react-components/src/index.js
@@ -7,4 +7,5 @@ export { default as PublisherSearch } from './search/PublisherSearch/Standalone'
 export { default as Collection } from './entities/Collection/Standalone';
 export { default as Institution } from './entities/Institution/Standalone';
 export { default as Dataset } from './entities/Dataset/Standalone';
+export { default as App } from './App';
 export { default as themeBuilder } from './style/themeBuilder';


### PR DESCRIPTION
https://github.com/gbif/gbif-web/issues/330

To make it easier to opt in on new routes. E.g. a new dataset search or dataset detail page. Without having to add the routes explicitly in e.g. the hosted portal, but just inherit default ones.
Else adding new endpoint and subroutes (like `dataset/:key/dashboard`) becomes heavy as everyone has to update their own config.