### PR TITLE
improve mobile a11y for site nav and footer

### DIFF
--- a/packages/gbif-org/src/components/ui/sheet.tsx
+++ b/packages/gbif-org/src/components/ui/sheet.tsx
@@ -64,8 +64,8 @@ const SheetContent = React.forwardRef<
         className={cn(sheetVariants({ side }), className)}
         {...props}
       >
-        <SheetPrimitive.Close className="g-absolute g-end-4 g-top-4 g-rounded-sm g-opacity-70 g-ring-offset-background g-transition-opacity hover:g-opacity-100 focus:g-outline-none focus:g-ring-2 focus:g-ring-ring focus:g-ring-offset-2 disabled:g-pointer-events-none data-[state=open]:g-bg-secondary">
-          <Cross2Icon className="g-h-4 g-w-4" />
+        <SheetPrimitive.Close className="g-absolute g-end-2 g-top-2 g-inline-flex g-h-11 g-w-11 g-items-center g-justify-center g-rounded-sm g-opacity-70 g-ring-offset-background g-transition-opacity hover:g-opacity-100 focus:g-outline-none focus:g-ring-2 focus:g-ring-ring focus:g-ring-offset-2 disabled:g-pointer-events-none data-[state=open]:g-bg-secondary">
+          <Cross2Icon className="g-h-5 g-w-5" aria-hidden="true" />
           <span className="g-sr-only">Close</span>
         </SheetPrimitive.Close>
         {children}

--- a/packages/gbif-org/src/gbif/footer/index.tsx
+++ b/packages/gbif-org/src/gbif/footer/index.tsx
@@ -2,66 +2,79 @@ import { DynamicLink } from '@/reactRouterPlugins';
 import { FaFacebookF, FaLinkedinIn, FaMastodon } from 'react-icons/fa';
 import { FaBluesky } from 'react-icons/fa6';
 import { IoLogoVimeo } from 'react-icons/io5';
-import { FormattedMessage } from 'react-intl';
+import { FormattedMessage, useIntl } from 'react-intl';
 import gbifLogoUrl from './full-gbif-logo-white.svg';
 import gbcLogoUrl from './gbc.svg';
 
-const cssSeparator = "after:g-content-['|'] after:g-p-2";
+const cssSeparator = "after:g-content-['|'] after:g-px-2";
+const footerLink = 'g-inline-flex g-items-center g-py-2 g-min-h-9 sm:g-min-h-7 hover:g-underline';
+const socialLink =
+  'g-inline-flex g-w-11 g-h-11 g-bg-white g-rounded-full g-justify-center g-items-center hover:g-opacity-80';
 
 export function Footer() {
+  const intl = useIntl();
+  const footerNavLabel = intl.formatMessage({
+    id: 'footer.navAriaLabel',
+    defaultMessage: 'Footer',
+  });
+  const socialNavLabel = intl.formatMessage({
+    id: 'footer.socialNavAriaLabel',
+    defaultMessage: 'GBIF on social media',
+  });
+
   return (
-    <footer className="g-text-white">
-      <section className="g-bg-[#686a68] g-py-6 g-px-4 g-text-sm">
-        <nav>
+    <footer className="g-text-white" role="contentinfo">
+      <section className="g-bg-[#686a68] g-py-6 g-px-4 g-text-base sm:g-text-sm">
+        <nav aria-label={footerNavLabel}>
           <ul className="g-flex g-justify-center g-w-full g-flex-wrap">
             <li className={cssSeparator}>
-              <DynamicLink to="/what-is-gbif">
+              <DynamicLink to="/what-is-gbif" className={footerLink}>
                 <FormattedMessage id="footer.whatIsGbif" defaultMessage="What is GBIF?" />
               </DynamicLink>
             </li>
             <li className={cssSeparator}>
-              <DynamicLink to="/developer/summary">
+              <DynamicLink to="/developer/summary" className={footerLink}>
                 <FormattedMessage id="footer.api" defaultMessage="API" />
               </DynamicLink>
             </li>
             <li className={cssSeparator}>
-              <DynamicLink to="/faq">
+              <DynamicLink to="/faq" className={footerLink}>
                 <FormattedMessage id="footer.faq" defaultMessage="FAQ" />
               </DynamicLink>
             </li>
             <li className={cssSeparator}>
-              <DynamicLink to="/subscribe">
+              <DynamicLink to="/subscribe" className={footerLink}>
                 <FormattedMessage id="footer.newsletter" defaultMessage="Newsletter" />
               </DynamicLink>
             </li>
             <li className={cssSeparator}>
-              <DynamicLink to="/terms/privacy-policy">
+              <DynamicLink to="/terms/privacy-policy" className={footerLink}>
                 <FormattedMessage id="footer.privacy" defaultMessage="Privacy" />
               </DynamicLink>
             </li>
             <li className={cssSeparator}>
-              <DynamicLink to="/terms">
+              <DynamicLink to="/terms" className={footerLink}>
                 <FormattedMessage id="footer.terms" defaultMessage="Terms and agreements" />
               </DynamicLink>
             </li>
             <li className={cssSeparator}>
-              <DynamicLink to="/citation-guidelines">
+              <DynamicLink to="/citation-guidelines" className={footerLink}>
                 <FormattedMessage id="footer.citation" defaultMessage="Citation" />
               </DynamicLink>
             </li>
             <li className={cssSeparator}>
-              <DynamicLink to="/code-of-conduct">
+              <DynamicLink to="/code-of-conduct" className={footerLink}>
                 <FormattedMessage id="footer.codeOfConduct" defaultMessage="Code of Conduct" />
               </DynamicLink>
             </li>
             <li>
-              <DynamicLink to="/acknowledgements">
+              <DynamicLink to="/acknowledgements" className={footerLink}>
                 <FormattedMessage id="footer.acknowledgements" defaultMessage="Acknowledgements" />
               </DynamicLink>
             </li>
           </ul>
-          <address className="g-pt-4 g-not-italic g-flex g-w-full g-justify-center g-flex-wrap">
-            <DynamicLink to="/contact-us" className={cssSeparator}>
+          <address className="g-mt-2 g-not-italic g-flex g-w-full g-justify-center g-flex-wrap g-items-center">
+            <DynamicLink to="/contact-us" className={`${cssSeparator} ${footerLink}`}>
               <FormattedMessage id="footer.contact" defaultMessage="Contact" />
             </DynamicLink>
             <span className="g-font-semibold">GBIF Secretariat&nbsp;</span>
@@ -71,61 +84,64 @@ export function Footer() {
           </address>
         </nav>
       </section>
-      <section className="g-bg-[#5b5b5b] g-flex g-w-full g-justify-center g-py-6 g-px-6 g-text-sm">
-        <DynamicLink to="/news/6PHdgoyIF6RmI7u4VOouuD" className="g-flex g-items-center">
-          <img src={gbcLogoUrl} className="g-h-10 g-p-r-6" />
+      <section className="g-bg-[#5b5b5b] g-flex g-w-full g-justify-center g-py-6 g-px-6 g-text-base sm:g-text-sm">
+        <DynamicLink
+          to="/news/6PHdgoyIF6RmI7u4VOouuD"
+          className="g-flex g-items-center g-min-h-11 hover:g-underline"
+        >
+          <img src={gbcLogoUrl} className="g-h-10 g-p-r-6" alt="" />
           <span className="g-ps-4">
             <span className="g-font-semibold">GBIF</span> is a Global Core Biodata Resource
           </span>
         </DynamicLink>
       </section>
       <section className="g-bg-[#414141] g-text-[#414141] g-py-6 g-px-6">
-        <ul className="g-flex g-w-full g-justify-center g-items-center g-gap-5 g-flex-wrap">
+        <ul
+          className="g-flex g-w-full g-justify-center g-items-center g-gap-5 g-flex-wrap"
+          aria-label={socialNavLabel}
+        >
           <li>
             <a
               href="https://www.linkedin.com/company/gbif"
-              className="g-w-8 g-h-8 g-bg-white g-rounded-full g-flex g-justify-center g-items-center"
+              aria-label="LinkedIn"
+              className={socialLink}
             >
-              <FaLinkedinIn />
+              <FaLinkedinIn aria-hidden="true" />
             </a>
           </li>
           <li>
             <a
               href="https://www.facebook.com/gbifnews"
-              className="g-w-8 g-h-8 g-bg-white g-rounded-full g-flex g-justify-center g-items-center"
+              aria-label="Facebook"
+              className={socialLink}
             >
-              <FaFacebookF />
+              <FaFacebookF aria-hidden="true" />
             </a>
           </li>
           <li>
-            <a
-              href="https://bsky.app/profile/gbif.org"
-              className="g-w-8 g-h-8 g-bg-white g-rounded-full g-flex g-justify-center g-items-center"
-            >
-              <FaBluesky />
+            <a href="https://bsky.app/profile/gbif.org" aria-label="Bluesky" className={socialLink}>
+              <FaBluesky aria-hidden="true" />
             </a>
           </li>
           <li>
             <a
               href="https://biodiversity.social/@gbif"
               rel="me"
-              className="g-w-8 g-h-8 g-bg-white g-rounded-full g-flex g-justify-center g-items-center"
+              aria-label="Mastodon"
+              className={socialLink}
             >
-              <FaMastodon size={18} />
+              <FaMastodon size={18} aria-hidden="true" />
             </a>
           </li>
           <li>
-            <a
-              href="https://vimeo.com/gbif"
-              className="g-w-8 g-h-8 g-bg-white g-rounded-full g-flex g-justify-center g-items-center"
-            >
-              <IoLogoVimeo size={18} />
+            <a href="https://vimeo.com/gbif" aria-label="Vimeo" className={socialLink}>
+              <IoLogoVimeo size={18} aria-hidden="true" />
             </a>
           </li>
         </ul>
       </section>
       <section className="g-bg-[#222222] g-py-6 g-px-6 g-flex g-justify-center g-w-full">
-        <img className="g-h-[40px]" src={gbifLogoUrl} />
+        <img className="g-h-[40px]" src={gbifLogoUrl} alt="GBIF" />
       </section>
     </footer>
   );

--- a/packages/gbif-org/src/gbif/gbifRootLayout.tsx
+++ b/packages/gbif-org/src/gbif/gbifRootLayout.tsx
@@ -6,6 +6,7 @@ import { UserProvider } from '@/contexts/UserContext';
 import { HeaderQuery, HomePageQuery } from '@/gql/graphql';
 import { LoaderArgs } from '@/reactRouterPlugins';
 import React from 'react';
+import { FormattedMessage } from 'react-intl';
 import { json, ScrollRestoration, useLoaderData } from 'react-router-dom';
 import { Footer } from './footer';
 import { Header } from './header';
@@ -95,9 +96,15 @@ const LayoutInner = React.memo(
     return (
       <UserProvider>
         <div className="g-flex g-flex-col g-min-h-[100dvh]">
+          <a
+            href="#main-content"
+            className="g-sr-only focus:g-not-sr-only focus:g-fixed focus:g-top-2 focus:g-start-2 focus:g-z-50 focus:g-bg-primary focus:g-text-primaryContrast focus:g-px-4 focus:g-py-2 focus:g-rounded-md focus:g-shadow-lg focus:g-outline-none focus:g-ring-2 focus:g-ring-ring"
+          >
+            <FormattedMessage id="header.skipToMainContent" defaultMessage="Skip to main content" />
+          </a>
           <LoadingIndicator />
           <Header menu={redirectTools(data)} />
-          <main className="g-flex-auto">
+          <main className="g-flex-auto" id="main-content" tabIndex={-1}>
             <AlternativeLanguages />
             <NoscriptNotification />
             <ScrollRestoration />

--- a/packages/gbif-org/src/gbif/header/SearchTrigger.tsx
+++ b/packages/gbif-org/src/gbif/header/SearchTrigger.tsx
@@ -15,26 +15,34 @@ import {
 import { Setter } from '@/types';
 
 export function SearchTrigger() {
+  const intl = useIntl();
   const [open, setOpen] = useState(false);
+
+  const searchLabel = intl.formatMessage({
+    id: 'header.search',
+    defaultMessage: 'Search',
+  });
 
   return (
     <>
       {/* Mobile: direct link to omni search (visible <sm) */}
       <div className="sm:g-hidden">
-        <Button variant="ghost" asChild className="g-text-xl g-px-2 g-mx-0.5">
-          <DynamicLink pageId="omniSearch" className="g-opacity-80">
-            <MdSearch />
+        <Button variant="ghost" asChild className="g-text-2xl g-px-2 g-mx-0.5 g-min-h-11 g-min-w-11">
+          <DynamicLink pageId="omniSearch" className="g-opacity-80" aria-label={searchLabel}>
+            <MdSearch aria-hidden="true" />
           </DynamicLink>
         </Button>
       </div>
       {/* Desktop: popover with search field (hidden <sm) */}
       <div className="g-hidden sm:g-inline-block">
         <Popover open={open} onOpenChange={setOpen}>
-          <PopoverTrigger>
-            <Button variant="ghost" asChild className="g-text-xl g-px-2 g-mx-0.5">
-              <span className="g-opacity-80">
-                <MdSearch />
-              </span>
+          <PopoverTrigger asChild>
+            <Button
+              variant="ghost"
+              className="g-text-xl g-px-2 g-mx-0.5 g-opacity-80"
+              aria-label={searchLabel}
+            >
+              <MdSearch aria-hidden="true" />
             </Button>
           </PopoverTrigger>
           <PopoverContent className="g-w-[24rem] g-p-0">

--- a/packages/gbif-org/src/gbif/header/index.tsx
+++ b/packages/gbif-org/src/gbif/header/index.tsx
@@ -19,10 +19,11 @@ import SearchTrigger from './SearchTrigger';
 import { cn } from '@/utils/shadcn';
 import useQuery from '@/hooks/useQuery';
 import { useEffect, useRef } from 'react';
-import { FormattedMessage } from 'react-intl';
+import { FormattedMessage, useIntl } from 'react-intl';
 import { useNavOverflow } from '@/hooks/useNavOverflow';
 
 export function Header({ menu }: { menu: HeaderQuery }) {
+  const intl = useIntl();
   const containerRef = useRef<HTMLDivElement>(null);
   const contentRef = useRef<HTMLDivElement>(null);
   const rightSideRef = useRef<HTMLDivElement>(null);
@@ -31,6 +32,9 @@ export function Header({ menu }: { menu: HeaderQuery }) {
   // Before JS measurement, fall back to CSS `lg:` breakpoint classes (same as before).
   // After measurement, use the JS boolean to toggle visibility.
   const showMobile = hasMeasured ? isOverflowing : undefined;
+  // When the desktop nav is collapsed it is still in the DOM. Mark it as `inert`
+  // so it cannot receive focus or be read by assistive tech.
+  const desktopNavInert = showMobile === true ? { inert: '' } : {};
 
   return (
     <Container>
@@ -46,6 +50,7 @@ export function Header({ menu }: { menu: HeaderQuery }) {
           })}
           aria-hidden={showMobile === undefined ? undefined : showMobile || undefined}
           ref={contentRef}
+          {...desktopNavInert}
         >
           <MainNavigation menu={menu} />
         </div>
@@ -54,19 +59,29 @@ export function Header({ menu }: { menu: HeaderQuery }) {
         <SearchTrigger />
         <LanguageSelector
           trigger={
-            <Button variant="ghost" asChild className="g-text-xl g-px-2 g-mx-0.5 g-opacity-80">
-              <span>
-                <MdTranslate />
-              </span>
+            <Button
+              variant="ghost"
+              className="g-text-xl g-px-2 g-mx-0.5 g-opacity-80 g-min-h-11 g-min-w-11"
+              aria-label={intl.formatMessage({
+                id: 'header.changeLanguage',
+                defaultMessage: 'Change language',
+              })}
+            >
+              <MdTranslate aria-hidden="true" />
             </Button>
           }
         />
         <FeedbackPopover
           trigger={
-            <Button variant="ghost" asChild className="g-text-xl g-px-2 g-mx-0.5 g-opacity-80">
-              <span>
-                <MdOutlineFeedback />
-              </span>
+            <Button
+              variant="ghost"
+              className="g-text-xl g-px-2 g-mx-0.5 g-opacity-80 g-min-h-11 g-min-w-11"
+              aria-label={intl.formatMessage({
+                id: 'header.feedback',
+                defaultMessage: 'Send feedback',
+              })}
+            >
+              <MdOutlineFeedback aria-hidden="true" />
             </Button>
           }
         />
@@ -106,6 +121,7 @@ const STATUS_PAGE_QUERY = /* GraphQL */ `
 `;
 
 function StatusIndicator() {
+  const intl = useIntl();
   const { data, load } = useQuery<StatusPageIndicatorQuery, StatusPageIndicatorQueryVariables>(
     STATUS_PAGE_QUERY,
     { notifyOnErrors: false, throwAllErrors: false, lazyLoad: true }
@@ -129,17 +145,34 @@ function StatusIndicator() {
     return () => clearInterval(interval);
   }, [load, data?.statusPage?.notificationIcon?.showNotification]);
 
+  const hasNotification = !!data?.statusPage?.notificationIcon?.showNotification;
+  const statusLabel = hasNotification
+    ? intl.formatMessage({
+        id: 'header.systemStatusWithNotification',
+        defaultMessage: 'System status (active notification)',
+      })
+    : intl.formatMessage({
+        id: 'header.systemStatus',
+        defaultMessage: 'System status',
+      });
+
   return (
-    <Button variant="ghost" asChild className="g-text-xl g-px-2 g-mx-0.5 g-relative">
+    <Button
+      variant="ghost"
+      asChild
+      className="g-text-xl g-px-2 g-mx-0.5 g-relative g-min-h-11 g-min-w-11"
+    >
       <a
         href={import.meta.env.PUBLIC_STATUS_PAGE_URL ?? 'http://status.gbif.org/'}
         className="g-opacity-80"
+        aria-label={statusLabel}
       >
-        <FiActivity />
-        {data?.statusPage?.notificationIcon?.showNotification && (
+        <FiActivity aria-hidden="true" />
+        {hasNotification && (
           <span
-            style={{ backgroundColor: data.statusPage.notificationIcon.color }}
+            style={{ backgroundColor: data!.statusPage!.notificationIcon!.color }}
             className={cn('g-absolute g-top-2 g-end-2 g-w-2 g-h-2 g-rounded-full')}
+            aria-hidden="true"
           ></span>
         )}
       </a>
@@ -164,6 +197,7 @@ function Container({ children }: { children: React.ReactNode }) {
 }
 
 function Logo() {
+  const intl = useIntl();
   const config = useConfig();
   const isRoot = useIsRoot();
 
@@ -171,23 +205,42 @@ function Logo() {
     <DynamicLink
       as={NavLink}
       to="/"
-      className={cn('g-py-2 g-relative g-text-primary-500', {
-        'g-text-white': isRoot,
-        'test-box': config.testSite,
+      aria-label={intl.formatMessage({
+        id: 'header.homeLinkLabel',
+        defaultMessage: 'GBIF home',
       })}
+      className={cn(
+        'g-py-2 g-relative g-text-primary-500 g-inline-flex g-items-center g-min-h-11',
+        {
+          'g-text-white': isRoot,
+          'test-box': config.testSite,
+        }
+      )}
     >
-      <GbifLogoIcon style={{ fontSize: 25 }} />
+      <GbifLogoIcon style={{ fontSize: 25 }} aria-hidden="true" focusable="false" />
     </DynamicLink>
   );
 }
 
 function ProfileOrLogin() {
+  const intl = useIntl();
   const { user, isLoggedIn } = useUser();
 
   if (isLoggedIn && user) {
     return (
       <Button asChild className="g-text-sm" variant="outline">
-        <DynamicLink to="/user/profile">{user.userName}</DynamicLink>
+        <DynamicLink
+          to="/user/profile"
+          aria-label={intl.formatMessage(
+            {
+              id: 'header.profileLinkLabel',
+              defaultMessage: 'Profile page for {userName}',
+            },
+            { userName: user.userName }
+          )}
+        >
+          {user.userName}
+        </DynamicLink>
       </Button>
     );
   }

--- a/packages/gbif-org/src/gbif/header/languageSelector.tsx
+++ b/packages/gbif-org/src/gbif/header/languageSelector.tsx
@@ -45,21 +45,39 @@ export function LanguageSelector({ trigger = <MdTranslate /> }): React.ReactElem
           <DropdownMenuSeparator />
           {languages
             .filter((language) => primaryTranslations.includes(language.code))
-            .map((language) => (
-              <DropdownMenuItem key={language.code} onClick={() => setLocale(language.code)}>
-                <span className="g-w-5">{locale.code === language.code && <MdCheck />}</span>
-                {language.label}
-              </DropdownMenuItem>
-            ))}
+            .map((language) => {
+              const isCurrent = locale.code === language.code;
+              return (
+                <DropdownMenuItem
+                  key={language.code}
+                  onClick={() => setLocale(language.code)}
+                  aria-current={isCurrent ? 'true' : undefined}
+                >
+                  <span className="g-w-5" aria-hidden="true">
+                    {isCurrent && <MdCheck />}
+                  </span>
+                  {language.label}
+                </DropdownMenuItem>
+              );
+            })}
           <DropdownMenuSeparator />
           {languages
             .filter((language) => !primaryTranslations.includes(language.code))
-            .map((language) => (
-              <DropdownMenuItem key={language.code} onClick={() => setLocale(language.code)}>
-                <span className="g-w-5">{locale.code === language.code && <MdCheck />}</span>
-                {language.label}
-              </DropdownMenuItem>
-            ))}
+            .map((language) => {
+              const isCurrent = locale.code === language.code;
+              return (
+                <DropdownMenuItem
+                  key={language.code}
+                  onClick={() => setLocale(language.code)}
+                  aria-current={isCurrent ? 'true' : undefined}
+                >
+                  <span className="g-w-5" aria-hidden="true">
+                    {isCurrent && <MdCheck />}
+                  </span>
+                  {language.label}
+                </DropdownMenuItem>
+              );
+            })}
         </div>
       </DropdownMenuContent>
     </DropdownMenu>

--- a/packages/gbif-org/src/gbif/header/mobileMenu.tsx
+++ b/packages/gbif-org/src/gbif/header/mobileMenu.tsx
@@ -21,20 +21,29 @@ import { DynamicLink, useI18n } from '@/reactRouterPlugins';
 import { VisuallyHidden } from '@radix-ui/react-visually-hidden';
 import { memo, useState } from 'react';
 import { MdLink, MdMenu } from 'react-icons/md';
+import { FormattedMessage, useIntl } from 'react-intl';
 
 function MobileMenu({ menu }: { menu: HeaderQuery }) {
   const { locale } = useI18n();
+  const intl = useIntl();
   const [open, setOpen] = useState(false);
   const { user, isLoggedIn, isLoading } = useUser();
+
+  const openMenuLabel = intl.formatMessage({
+    id: 'header.openNavigationMenu',
+    defaultMessage: 'Open navigation menu',
+  });
 
   const children = menu?.gbifHome?.children;
   return (
     <Sheet open={open} onOpenChange={setOpen}>
-      <SheetTrigger>
-        <Button variant="ghost" asChild className="g-text-xl g-px-2 g-mx-0.5">
-          <span>
-            <MdMenu className="g-opacity-80" />
-          </span>
+      <SheetTrigger asChild>
+        <Button
+          variant="ghost"
+          className="g-text-2xl g-px-2 g-mx-0.5 g-min-h-11 g-min-w-11"
+          aria-label={openMenuLabel}
+        >
+          <MdMenu className="g-opacity-80" aria-hidden="true" />
         </Button>
       </SheetTrigger>
       <SheetContent
@@ -56,7 +65,13 @@ function MobileMenu({ menu }: { menu: HeaderQuery }) {
             </VisuallyHidden>
           </SheetHeader>
 
-          <div className="g-text-sm g-my-4">
+          <nav
+            className="g-text-base g-my-4"
+            aria-label={intl.formatMessage({
+              id: 'header.siteNavigation',
+              defaultMessage: 'Site navigation',
+            })}
+          >
             <Accordion type="single" collapsible className="w-full">
               {children?.map((parent) => {
                 if (!parent.children || parent.children.length === 0) {
@@ -65,35 +80,40 @@ function MobileMenu({ menu }: { menu: HeaderQuery }) {
                       onClick={() => setOpen(false)}
                       key={parent.id}
                       to={parent.link}
-                      className="g-border-b g-flex g-flex-1 g-items-center g-justify-between g-py-2 g-text-sm g-transition-all hover:g-underline"
+                      className="g-border-b g-flex g-flex-1 g-items-center g-justify-between g-py-4 g-min-h-11 g-text-base g-transition-all hover:g-underline"
                     >
                       <div>
-                        {parent.title} {parent.externalLink && <MdLink />}
+                        {parent.title} {parent.externalLink && <MdLink aria-hidden="true" />}
                       </div>
                     </DynamicLink>
                   );
                 }
                 return (
                   <AccordionItem value={parent.id} key={parent.id}>
-                    <AccordionTrigger>{parent.title}</AccordionTrigger>
+                    <AccordionTrigger className="g-py-4 g-min-h-11 g-text-base">
+                      {parent.title}
+                    </AccordionTrigger>
                     <AccordionContent>
-                      <div className="g-bg-slate-200 g-rounded-lg g-px-2">
+                      <div className="g-bg-slate-200 g-rounded-lg g-px-3">
                         <Accordion type="multiple" className="w-full">
                           {parent.children.map((child) => {
                             if (child.children && child.children.length > 0) {
                               return (
                                 <AccordionItem value={child.id} key={child.id}>
-                                  <AccordionTrigger>{child.title}</AccordionTrigger>
+                                  <AccordionTrigger className="g-py-4 g-min-h-11 g-text-base">
+                                    {child.title}
+                                  </AccordionTrigger>
                                   <AccordionContent className="g-ms-0">
                                     {child.children.map((subChild) => (
                                       <DynamicLink
                                         onClick={() => setOpen(false)}
                                         key={subChild.id}
                                         to={subChild.link}
-                                        className="g-text-muted-foreground g-border-b g-flex g-flex-1 g-items-center g-justify-between g-py-2 g-text-sm g-transition-all hover:g-underline"
+                                        className="g-text-muted-foreground g-border-b g-flex g-flex-1 g-items-center g-justify-between g-py-3 g-min-h-11 g-text-base g-transition-all hover:g-underline"
                                       >
                                         <div>
-                                          {subChild.title} {subChild.externalLink && <MdLink />}
+                                          {subChild.title}{' '}
+                                          {subChild.externalLink && <MdLink aria-hidden="true" />}
                                         </div>
                                       </DynamicLink>
                                     ))}
@@ -106,10 +126,11 @@ function MobileMenu({ menu }: { menu: HeaderQuery }) {
                                 onClick={() => setOpen(false)}
                                 key={child.id}
                                 to={child.link}
-                                className="g-border-b g-flex g-flex-1 g-items-center g-justify-between g-py-2 g-text-sm g-transition-all hover:g-underline"
+                                className="g-border-b g-flex g-flex-1 g-items-center g-justify-between g-py-3 g-min-h-11 g-text-base g-transition-all hover:g-underline"
                               >
                                 <div>
-                                  {child.title} {child.externalLink && <MdLink />}
+                                  {child.title}{' '}
+                                  {child.externalLink && <MdLink aria-hidden="true" />}
                                 </div>
                               </DynamicLink>
                             );
@@ -127,22 +148,33 @@ function MobileMenu({ menu }: { menu: HeaderQuery }) {
                   <DynamicLink
                     onClick={() => setOpen(false)}
                     to="/user/profile"
-                    className="g-block g-border-b g-font-medium *:g-flex g-flex-1 g-items-center g-justify-between g-py-4 g-text-sm g-transition-all hover:g-underline"
+                    aria-label={intl.formatMessage(
+                      {
+                        id: 'header.profileLinkLabel',
+                        defaultMessage: 'My profile: {userName}',
+                      },
+                      { userName: user.userName }
+                    )}
+                    className="g-block g-border-b g-font-medium *:g-flex g-flex-1 g-items-center g-justify-between g-py-4 g-min-h-11 g-text-base g-transition-all hover:g-underline"
                   >
-                    {user.userName}
+                    <FormattedMessage
+                      id="header.profile"
+                      defaultMessage="Profile"
+                      values={{ userName: user.userName }}
+                    />
                   </DynamicLink>
                 ) : (
                   <DynamicLink
                     onClick={() => setOpen(false)}
                     to="/user/login"
-                    className="g-block g-border-b g-font-medium *:g-flex g-flex-1 g-items-center g-justify-between g-py-4 g-text-sm g-transition-all hover:g-underline"
+                    className="g-block g-border-b g-font-medium *:g-flex g-flex-1 g-items-center g-justify-between g-py-4 g-min-h-11 g-text-base g-transition-all hover:g-underline"
                   >
-                    Login
+                    <FormattedMessage id="profile.loginText" defaultMessage="Login" />
                   </DynamicLink>
                 )}
               </>
             )}
-          </div>
+          </nav>
         </ClientSideOnly>
       </SheetContent>
     </Sheet>

--- a/packages/gbif-org/src/index.css
+++ b/packages/gbif-org/src/index.css
@@ -1030,3 +1030,15 @@ Constrain images and videos to the parent width and preserve their intrinsic asp
 .gbif-map-popup-bare .maplibregl-popup-tip {
   display: none;
 }
+
+/* Respect users who request reduced motion */
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}

--- a/packages/react-components/locales/scripts/stitchFile.js
+++ b/packages/react-components/locales/scripts/stitchFile.js
@@ -29,6 +29,7 @@ function builder({ locale = 'en', folder = 'translations', keepEmptyStrings = fa
       intervals: getFile(locale, `../${folder}/${locale}/components/intervals`),
       filters: getFile(locale, `../${folder}/${locale}/components/filters`),
       feedback: getFile(locale, `../${folder}/${locale}/components/feedback`).feedback,
+      header: getFile(locale, `../${folder}/${locale}/components/header`).header,
       filterSupport: getFile(locale, `../${folder}/${locale}/components/filterSupport`),
       counts: getFile(locale, `../${folder}/${locale}/components/counts`),
       contact: getFile(locale, `../${folder}/${locale}/components/contact`),

--- a/packages/react-components/locales/source/en-developer/components/footer.json
+++ b/packages/react-components/locales/source/en-developer/components/footer.json
@@ -9,6 +9,8 @@
     "citation": "Citation",
     "codeOfConduct": " Code of conduct",
     "acknowledgements": "Acknowledgements",
+    "socialNavAriaLabel": "GBIF on social media",
+    "navAriaLabel": "Footer",
     "contact": "Contact"
   }
 }

--- a/packages/react-components/locales/source/en-developer/components/header.json
+++ b/packages/react-components/locales/source/en-developer/components/header.json
@@ -1,0 +1,11 @@
+{
+  "header": {
+    "changeLanguage": "Change language",
+    "feedback": "Send feedback",
+    "systemStatus": "System status",
+    "profileLinkLabel": "Profile page for {userName}",
+    "siteNavigation": "Site navigation",
+    "search": "Search",
+    "profile": "User profile"
+  }
+}


### PR DESCRIPTION
    - bump nav/footer text to 16px and enlarge tap targets to 44px
    - add aria-labels to all icon-only controls (logo, search, status, language, feedback, hamburger, social icons)
    - enlarge drawer close button tap target
    - mark hidden desktop nav as inert at mobile widths
    - add skip-to-main-content link and id on <main>
    - label footer landmark and footer nav; wrap drawer items in <nav>
    - announce active language with aria-current in the language menu
    - give the profile link descriptive text and aria-label
    - honour prefers-reduced-motion for animations and transitions