### PR TITLE
graphql-api: forward x-client-priority header to upstream APIs

### DIFF
--- a/packages/graphql-api/src/helpers/omniSearch/taxonSearch.ts
+++ b/packages/graphql-api/src/helpers/omniSearch/taxonSearch.ts
@@ -135,6 +135,7 @@ async function getTaxonDetails(
     abortController: new AbortController(),
     userAgent: 'GBIF_GRAPHQL_API',
     referer: null,
+    clientPriority: null,
     locale: 'en-GB',
     preview: false,
   });

--- a/packages/graphql-api/src/index.ts
+++ b/packages/graphql-api/src/index.ts
@@ -106,6 +106,10 @@ async function initializeServer() {
       userAgent: get(req, 'headers.User-Agent') || 'GBIF_GRAPHQL_API',
       // we could also forward the full header I suppose. For now it is just the referer
       referer: get(req, 'headers.referer') || null,
+      // x-client-priority is attached by Varnish (1-100, lower = more important).
+      // We forward it to the upstream APIs so they can prioritise/shed under load
+      // — most importantly the es-api behind occurrence search. null when absent.
+      clientPriority: get(req, 'headers.x-client-priority') || null,
       locale: get(req, 'headers.locale') || 'en-GB',
       preview: get(req, 'headers.preview') === 'true',
       queryId: res ? res.get('X-Graphql-query-ID') : null,

--- a/packages/graphql-api/src/resources/collection/collection.source.js
+++ b/packages/graphql-api/src/resources/collection/collection.source.js
@@ -11,6 +11,7 @@ class CollectionAPI extends RESTDataSource {
   willSendRequest(path, request) {
     request.headers['User-Agent'] = this.context.userAgent;
     request.headers['referer'] = this.context.referer;
+    request.headers['x-client-priority'] = this.context.clientPriority;
     request.agent = getDefaultAgent(this.baseURL, path);
   }
 

--- a/packages/graphql-api/src/resources/country/country.source.js
+++ b/packages/graphql-api/src/resources/country/country.source.js
@@ -10,6 +10,7 @@ class CollectionAPI extends RESTDataSource {
   willSendRequest(path, request) {
     request.headers['User-Agent'] = this.context.userAgent;
     request.headers['referer'] = this.context.referer;
+    request.headers['x-client-priority'] = this.context.clientPriority;
     request.agent = getDefaultAgent(this.baseURL, path);
   }
 

--- a/packages/graphql-api/src/resources/dataset/dataset.source.js
+++ b/packages/graphql-api/src/resources/dataset/dataset.source.js
@@ -17,6 +17,7 @@ class DatasetAPI extends QueuedRESTDataSource {
   willSendRequest(path, request) {
     request.headers['User-Agent'] = this.context.userAgent;
     request.headers.referer = this.context.referer;
+    request.headers['x-client-priority'] = this.context.clientPriority;
     request.agent = getDefaultAgent(this.baseURL, path);
   }
 

--- a/packages/graphql-api/src/resources/dataset/datasetByPredicate.source.js
+++ b/packages/graphql-api/src/resources/dataset/datasetByPredicate.source.js
@@ -16,6 +16,7 @@ class DatasetByPredicateAPI extends RESTDataSource {
     request.headers['Authorization'] = `ApiKey-v1 ${this.config.apiEsKey}`;
     request.headers['User-Agent'] = this.context.userAgent;
     request.headers['referer'] = this.context.referer;
+    request.headers['x-client-priority'] = this.context.clientPriority;
     request.agent = getDefaultAgent(this.baseURL, path);
   }
 

--- a/packages/graphql-api/src/resources/directoryPerson/directoryPerson.source.js
+++ b/packages/graphql-api/src/resources/directoryPerson/directoryPerson.source.js
@@ -22,6 +22,7 @@ class DirectoryPersonAPI extends RESTDataSource {
     Object.keys(header).forEach((x) => { request.headers[x] = header[x]; });
     request.headers['User-Agent'] = this.context.userAgent;
     request.headers['referer'] = this.context.referer;
+    request.headers['x-client-priority'] = this.context.clientPriority;
     request.agent = getDefaultAgent(this.baseURL, path);
   }
 

--- a/packages/graphql-api/src/resources/gadm/gadm.source.js
+++ b/packages/graphql-api/src/resources/gadm/gadm.source.js
@@ -11,6 +11,7 @@ class GadmAPI extends RESTDataSource {
   willSendRequest(path, request) {
     request.headers['User-Agent'] = this.context.userAgent;
     request.headers['referer'] = this.context.referer;
+    request.headers['x-client-priority'] = this.context.clientPriority;
     request.agent = getDefaultAgent(this.baseURL, path);
   }
 

--- a/packages/graphql-api/src/resources/installation/installation.source.js
+++ b/packages/graphql-api/src/resources/installation/installation.source.js
@@ -11,6 +11,7 @@ class InstallationAPI extends RESTDataSource {
   willSendRequest(path, request) {
     request.headers['User-Agent'] = this.context.userAgent;
     request.headers['referer'] = this.context.referer;
+    request.headers['x-client-priority'] = this.context.clientPriority;
     request.agent = getDefaultAgent(this.baseURL, path);
   }
 

--- a/packages/graphql-api/src/resources/institution/institution.source.js
+++ b/packages/graphql-api/src/resources/institution/institution.source.js
@@ -11,6 +11,7 @@ class InstitutionAPI extends RESTDataSource {
   willSendRequest(path, request) {
     request.headers['User-Agent'] = this.context.userAgent;
     request.headers['referer'] = this.context.referer;
+    request.headers['x-client-priority'] = this.context.clientPriority;
     request.agent = getDefaultAgent(this.baseURL, path);
   }
 

--- a/packages/graphql-api/src/resources/literature/literature.source.js
+++ b/packages/graphql-api/src/resources/literature/literature.source.js
@@ -15,6 +15,7 @@ class LiteratureAPI extends RESTDataSource {
     request.headers['Authorization'] = `ApiKey-v1 ${this.config.apiEsKey}`;
     request.headers['User-Agent'] = this.context.userAgent;
     request.headers['referer'] = this.context.referer;
+    request.headers['x-client-priority'] = this.context.clientPriority;
     request.agent = getDefaultAgent(this.baseURL, path);
   }
 

--- a/packages/graphql-api/src/resources/localContext/localContext.source.js
+++ b/packages/graphql-api/src/resources/localContext/localContext.source.js
@@ -68,6 +68,7 @@ class LocalContextAPI extends RESTDataSource {
     request.headers['X-Api-Key'] = this.config.localContextApiKey;
     request.headers['User-Agent'] = this.context.userAgent;
     request.headers['referer'] = this.context.referer;
+    request.headers['x-client-priority'] = this.context.clientPriority;
     request.agent = getDefaultAgent(this.baseURL, path);
   }
 

--- a/packages/graphql-api/src/resources/network/network.source.js
+++ b/packages/graphql-api/src/resources/network/network.source.js
@@ -11,6 +11,7 @@ class NetworkAPI extends RESTDataSource {
   willSendRequest(path, request) {
     request.headers['User-Agent'] = this.context.userAgent;
     request.headers['referer'] = this.context.referer;
+    request.headers['x-client-priority'] = this.context.clientPriority;
     request.agent = getDefaultAgent(this.baseURL, path);
   }
 

--- a/packages/graphql-api/src/resources/node/node.source.js
+++ b/packages/graphql-api/src/resources/node/node.source.js
@@ -14,6 +14,7 @@ export class NodeAPI extends RESTDataSource {
   willSendRequest(path, request) {
     request.headers['User-Agent'] = this.context.userAgent;
     request.headers['referer'] = this.context.referer;
+    request.headers['x-client-priority'] = this.context.clientPriority;
     request.agent = getDefaultAgent(this.baseURL, path);
   }
 
@@ -77,6 +78,7 @@ export class NodeDirectoryAPI extends RESTDataSource {
     Object.keys(header).forEach((x) => { request.headers[x] = header[x]; });
     request.headers['User-Agent'] = this.context.userAgent;
     request.headers['referer'] = this.context.referer;
+    request.headers['x-client-priority'] = this.context.clientPriority;
     request.agent = getDefaultAgent(this.baseURL, path);
   }
 

--- a/packages/graphql-api/src/resources/occurrence/occurrence.source.js
+++ b/packages/graphql-api/src/resources/occurrence/occurrence.source.js
@@ -22,6 +22,7 @@ class OccurrenceAPI extends QueuedRESTDataSource {
     request.headers['Authorization'] = `ApiKey-v1 ${this.config.apiEsKey}`;
     request.headers['User-Agent'] = this.context.userAgent;
     request.headers['referer'] = this.context.referer;
+    request.headers['x-client-priority'] = this.context.clientPriority;
     request.agent = getOccurrenceAgent(this.baseURL, path);
   }
 

--- a/packages/graphql-api/src/resources/organization/organization.source.js
+++ b/packages/graphql-api/src/resources/organization/organization.source.js
@@ -11,6 +11,7 @@ class OrganizationAPI extends RESTDataSource {
   willSendRequest(path, request) {
     request.headers['User-Agent'] = this.context.userAgent;
     request.headers['referer'] = this.context.referer;
+    request.headers['x-client-priority'] = this.context.clientPriority;
     request.agent = getDefaultAgent(this.baseURL, path);
   }
 

--- a/packages/graphql-api/src/resources/participant/participant.source.js
+++ b/packages/graphql-api/src/resources/participant/participant.source.js
@@ -30,6 +30,7 @@ class ParticipantDirectoryAPI extends RESTDataSource {
     Object.keys(header).forEach((x) => { request.headers[x] = header[x]; });
     request.headers['User-Agent'] = this.context.userAgent;
     request.headers['referer'] = this.context.referer;
+    request.headers['x-client-priority'] = this.context.clientPriority;
     request.agent = getDefaultAgent(this.baseURL, path);
   }
 

--- a/packages/graphql-api/src/resources/resource/resource.source.js
+++ b/packages/graphql-api/src/resources/resource/resource.source.js
@@ -16,6 +16,7 @@ export class ResourceAPI extends QueuedRESTDataSource {
   willSendRequest(path, request) {
     request.headers['User-Agent'] = this.context.userAgent;
     request.headers.referer = this.context.referer;
+    request.headers['x-client-priority'] = this.context.clientPriority;
     request.agent = getDefaultAgent(this.baseURL, path);
   }
 
@@ -54,6 +55,7 @@ export class ResourceSearchAPI extends RESTDataSource {
   willSendRequest(path, request) {
     request.headers['User-Agent'] = this.context.userAgent;
     request.headers.referer = this.context.referer;
+    request.headers['x-client-priority'] = this.context.clientPriority;
     request.agent = getDefaultAgent(this.baseURL, path);
   }
 

--- a/packages/graphql-api/src/resources/staffMember/staffMember.source.js
+++ b/packages/graphql-api/src/resources/staffMember/staffMember.source.js
@@ -11,6 +11,7 @@ class StaffMemberAPI extends RESTDataSource {
   willSendRequest(path, request) {
     request.headers['User-Agent'] = this.context.userAgent;
     request.headers['referer'] = this.context.referer;
+    request.headers['x-client-priority'] = this.context.clientPriority;
     request.agent = getDefaultAgent(this.baseURL, path);
   }
 

--- a/packages/graphql-api/src/resources/statusPage/statusPage.source.js
+++ b/packages/graphql-api/src/resources/statusPage/statusPage.source.js
@@ -10,6 +10,7 @@ class StatusPageAPI extends RESTDataSource {
   willSendRequest(path, request) {
     request.headers['User-Agent'] = this.context.userAgent;
     request.headers['referer'] = this.context.referer;
+    request.headers['x-client-priority'] = this.context.clientPriority;
     if (this.baseURL) {
       request.agent = getDefaultAgent(this.baseURL, path);
     }

--- a/packages/graphql-api/src/resources/taxon/taxon.source.js
+++ b/packages/graphql-api/src/resources/taxon/taxon.source.js
@@ -16,6 +16,7 @@ class TaxonAPI extends QueuedRESTDataSource {
   willSendRequest(path, request) {
     request.headers['User-Agent'] = this.context.userAgent;
     request.headers['referer'] = this.context.referer;
+    request.headers['x-client-priority'] = this.context.clientPriority;
     request.agent = getTaxonAgent(this.baseURL, path);
   }
 

--- a/packages/graphql-api/src/resources/taxonMedia/taxonMedia.source.js
+++ b/packages/graphql-api/src/resources/taxonMedia/taxonMedia.source.js
@@ -13,6 +13,7 @@ export default class TaxonMediaAPI extends RESTDataSource {
   willSendRequest(path, request) {
     request.headers['User-Agent'] = this.context.userAgent;
     request.headers['referer'] = this.context.referer;
+    request.headers['x-client-priority'] = this.context.clientPriority;
     request.headers['Accept'] = 'application/json';
     request.agent = getDefaultAgent(this.baseURL, path);
   }

--- a/packages/graphql-api/src/resources/vocabulary/vocabulary.source.js
+++ b/packages/graphql-api/src/resources/vocabulary/vocabulary.source.js
@@ -11,6 +11,7 @@ class VocabularyAPI extends RESTDataSource {
   willSendRequest(path, request) {
     request.headers['User-Agent'] = this.context.userAgent;
     request.headers['referer'] = this.context.referer;
+    request.headers['x-client-priority'] = this.context.clientPriority;
     request.agent = getDefaultAgent(this.baseURL, path);
   }
 


### PR DESCRIPTION
Varnish attaches an x-client-priority header (1-100, lower = more important) to GraphQL requests. Thread it through the per-request context and forward it to the upstream APIs the same way we already forward User-Agent and referer, so upstreams (most importantly the es-api behind occurrence search) can prioritise or shed requests under load.