### PR TITLE
add fallback /api/resource/search endpoint

### DIFF
--- a/packages/gbif-org/gbif/routes/resourceSearch/endpoints.mjs
+++ b/packages/gbif-org/gbif/routes/resourceSearch/endpoints.mjs
@@ -7,17 +7,37 @@ const CONTENT_SEARCH_ENDPOINT = publicEnv.PUBLIC_CONTENT_SEARCH;
 // error messages to the client - only a status code and this generic message.
 const GENERIC_ERROR_MESSAGE = 'Failed to fetch content search results';
 
+// Map of legacy parameter names to their new names on the content search API.
+// If a legacy param name shows up in the incoming request, it is renamed to the
+// new name before being forwarded. Add entries here as parameters get renamed,
+// e.g. { oldName: 'newName' }.
+const PARAM_RENAME_MAP = {
+  // legacyParam: 'newParam',
+};
+
+// Apply PARAM_RENAME_MAP to a query string, preserving values, ordering and
+// repeated params. Returns the rewritten query string (without leading '?').
+function renameParams(queryString) {
+  const params = new URLSearchParams(queryString);
+  const renamed = new URLSearchParams();
+  for (const [key, value] of params) {
+    renamed.append(PARAM_RENAME_MAP[key] ?? key, value);
+  }
+  return renamed.toString();
+}
+
 // Proxy legacy /api/resource/search?<params> requests to the new content search
-// API, forwarding the query string untouched (e.g. -> https://hp-search.gbif.org/content?<params>).
+// API (e.g. -> https://hp-search.gbif.org/content?<params>), renaming any params
+// listed in PARAM_RENAME_MAP along the way.
 async function resourceSearch(req, res) {
   if (!CONTENT_SEARCH_ENDPOINT) {
     res.status(500).json({ error: GENERIC_ERROR_MESSAGE });
     return;
   }
 
-  // Use the raw query string from originalUrl so parameters are forwarded exactly
-  // as received (preserving encoding and repeated params) rather than re-serialized.
-  const queryString = req.originalUrl.split('?')[1] ?? '';
+  // Take the raw query string from originalUrl, then apply param renames.
+  const rawQueryString = req.originalUrl.split('?')[1] ?? '';
+  const queryString = renameParams(rawQueryString);
   const url = queryString ? `${CONTENT_SEARCH_ENDPOINT}?${queryString}` : CONTENT_SEARCH_ENDPOINT;
 
   try {

--- a/packages/gbif-org/gbif/routes/resourceSearch/endpoints.mjs
+++ b/packages/gbif-org/gbif/routes/resourceSearch/endpoints.mjs
@@ -1,0 +1,44 @@
+import { publicEnv } from '../../envConfig.mjs';
+
+// New content search API that the legacy /api/resource/search endpoint proxies to.
+const CONTENT_SEARCH_ENDPOINT = publicEnv.PUBLIC_CONTENT_SEARCH;
+
+// Generic message used for all failures. We intentionally do not forward upstream
+// error messages to the client - only a status code and this generic message.
+const GENERIC_ERROR_MESSAGE = 'Failed to fetch content search results';
+
+// Proxy legacy /api/resource/search?<params> requests to the new content search
+// API, forwarding the query string untouched (e.g. -> https://hp-search.gbif.org/content?<params>).
+async function resourceSearch(req, res) {
+  if (!CONTENT_SEARCH_ENDPOINT) {
+    res.status(500).json({ error: GENERIC_ERROR_MESSAGE });
+    return;
+  }
+
+  // Use the raw query string from originalUrl so parameters are forwarded exactly
+  // as received (preserving encoding and repeated params) rather than re-serialized.
+  const queryString = req.originalUrl.split('?')[1] ?? '';
+  const url = queryString ? `${CONTENT_SEARCH_ENDPOINT}?${queryString}` : CONTENT_SEARCH_ENDPOINT;
+
+  try {
+    const response = await fetch(url, {
+      headers: { Accept: 'application/json' },
+    });
+
+    if (!response.ok) {
+      // Expose only the upstream status, never its error body.
+      res.status(response.status).json({ error: GENERIC_ERROR_MESSAGE });
+      return;
+    }
+
+    const data = await response.json();
+    res.json(data);
+  } catch (error) {
+    // Network/parse errors are swallowed - we surface a generic 502 instead.
+    res.status(502).json({ error: GENERIC_ERROR_MESSAGE });
+  }
+}
+
+export function register(app) {
+  app.get('/api/resource/search', resourceSearch);
+}

--- a/packages/gbif-org/gbif/routes/resourceSearch/endpoints.mjs
+++ b/packages/gbif-org/gbif/routes/resourceSearch/endpoints.mjs
@@ -3,6 +3,9 @@ import { publicEnv } from '../../envConfig.mjs';
 // New content search API that the legacy /api/resource/search endpoint proxies to.
 const CONTENT_SEARCH_ENDPOINT = publicEnv.PUBLIC_CONTENT_SEARCH;
 
+// Identifies this service (the gbif-org portal server) to the upstream API.
+const USER_AGENT = 'GBIF_ORG_PORTAL';
+
 // Generic message used for all failures. We intentionally do not forward upstream
 // error messages to the client - only a status code and this generic message.
 const GENERIC_ERROR_MESSAGE = 'Failed to fetch content search results';
@@ -42,7 +45,7 @@ async function resourceSearch(req, res) {
 
   try {
     const response = await fetch(url, {
-      headers: { Accept: 'application/json' },
+      headers: { Accept: 'application/json', 'User-Agent': USER_AGENT },
     });
 
     if (!response.ok) {

--- a/packages/gbif-org/gbif/server.js
+++ b/packages/gbif-org/gbif/server.js
@@ -13,6 +13,7 @@ import { register as registerRobots } from './routes/robots/index.mjs';
 import { register as registerSitemaps } from './routes/sitemaps/endpoints.mjs';
 import { register as registerUser } from './routes/user/endpoints.mjs';
 import { register as registerProxies } from './routes/proxy/proxy.mjs';
+import { register as registerResourceSearch } from './routes/resourceSearch/endpoints.mjs';
 import createGetRedirect from './middleware/redirects.mjs';
 // Load environment variables from .env files and merge them with process.env.
 const envFile = loadEnv('', process.cwd(), ['PUBLIC_']);
@@ -112,6 +113,7 @@ async function main() {
 
   registerUser(app);
   registerProxies(app);
+  registerResourceSearch(app);
   registerSitemaps(app);
   registerRobots(app);
 


### PR DESCRIPTION
The old website had a proxy API. In case something still calls it we remap it.
At some point we should add logging and monitor if it is still being used. For now it is okay to just handle it, we have more pressing matters